### PR TITLE
fix: 镜像升级后优先使用新版本

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,9 +14,45 @@ UPDATED_APP_MARKER="$UPDATED_APP_DIR/.telegram-panel-self-update"
 UPDATE_PENDING_MARKER="$UPDATED_APP_DIR/.telegram-panel-update-pending"
 UPDATE_ATTEMPTED_MARKER="$UPDATED_APP_DIR/.telegram-panel-update-attempted"
 UPDATE_CONFIRMED_MARKER="$UPDATED_APP_DIR/.telegram-panel-update-confirmed"
+IMAGE_VERSION_FILE="$DEFAULT_APP_DIR/version.txt"
+UPDATED_VERSION_FILE="$UPDATED_APP_DIR/version.txt"
 
 log() {
   printf '[telegram-panel-entrypoint] %s\n' "$*" >&2
+}
+
+read_version_file() {
+  if [ -f "$1" ]; then
+    tr -d '\r\n' < "$1"
+  fi
+}
+
+version_is_greater() {
+  # 发布版本是三段式语义版本；忽略 v 前缀和预发布/构建元数据。
+  left="${1#v}"
+  right="${2#v}"
+  left="${left%%+*}"
+  left="${left%%-*}"
+  right="${right%%+*}"
+  right="${right%%-*}"
+
+  awk -F. '
+    NR == 1 {
+      if (NF != 3 || $1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) exit 1
+      left1 = $1 + 0; left2 = $2 + 0; left3 = $3 + 0
+      next
+    }
+    NR == 2 {
+      if (NF != 3 || $1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) exit 1
+      if (($1 + 0) != left1) exit (($1 + 0) > left1 ? 1 : 0)
+      if (($2 + 0) != left2) exit (($2 + 0) > left2 ? 1 : 0)
+      exit (($3 + 0) > left3 ? 0 : 1)
+    }
+    { exit 1 }
+  ' <<EOF
+$left
+$right
+EOF
 }
 
 mkdir -p "$DATA_DIR" "$DATA_DIR/sessions" "$DATA_DIR/logs"
@@ -27,7 +63,21 @@ fi
 APP_DIR="$DEFAULT_APP_DIR"
 if [ -f "$UPDATED_APP_DIR/$APP_ENTRY" ]; then
   if [ -f "$UPDATE_CONFIRMED_MARKER" ]; then
-    APP_DIR="$UPDATED_APP_DIR"
+    IMAGE_VERSION="$(read_version_file "$IMAGE_VERSION_FILE")"
+    UPDATED_VERSION="$(read_version_file "$UPDATED_VERSION_FILE")"
+    if [ -n "$IMAGE_VERSION" ] && [ -n "$UPDATED_VERSION" ] \
+      && version_is_greater "$IMAGE_VERSION" "$UPDATED_VERSION"; then
+      OBSOLETE_APP_DIR="$DATA_DIR/app-obsolete-$(date +%Y%m%d%H%M%S)-$$"
+      if mv "$UPDATED_APP_DIR" "$OBSOLETE_APP_DIR"; then
+        APP_DIR="$DEFAULT_APP_DIR"
+        log "镜像版本 v$IMAGE_VERSION 高于持久化版本 v$UPDATED_VERSION，已归档旧版本并使用镜像目录"
+      else
+        APP_DIR="$DEFAULT_APP_DIR"
+        log "无法归档旧持久化版本，为避免阻塞镜像升级，使用镜像目录：$DEFAULT_APP_DIR"
+      fi
+    else
+      APP_DIR="$UPDATED_APP_DIR"
+    fi
   elif [ -f "$UPDATE_ATTEMPTED_MARKER" ]; then
     FAILED_APP_DIR="$DATA_DIR/app-failed-$(date +%Y%m%d%H%M%S)-$$"
     log "检测到新版本上次启动未确认，正在归档失败版本：$FAILED_APP_DIR"

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -45,6 +45,14 @@ ghcr.io/moeacgx/telegram-panel:dev-latest
 4. 重建 `telegram-panel` 容器；
 5. 检查容器状态、最近日志、`/ui/dashboard` 和 `/api/panel/auth/me`。
 
+入口脚本会比较镜像内的 `version.txt` 与持久化自更新目录 `/data/app-current/version.txt`：
+
+- 镜像版本更高时，优先启动镜像版本，并将旧的持久化程序目录归档为 `/data/app-obsolete-*`；
+- 持久化自更新版本更高时，继续优先使用已确认启动成功的自更新版本；
+- 旧版本包没有 `version.txt` 时保持兼容行为，仍按启动确认标记选择目录。
+
+因此，升级 Docker 镜像后如果页面仍显示旧版本，应先查看容器日志中的版本选择记录和 `/data/app-obsolete-*`，确认是否存在旧自更新目录残留。
+
 部署完成不等于验收完成。验收时还要实际操作本次改动涉及的页面、API、后台任务或代理链路，并记录：
 
 - `dev` 提交 SHA 和实际镜像标签；

--- a/src/TelegramPanel.Web/TelegramPanel.Web.csproj
+++ b/src/TelegramPanel.Web/TelegramPanel.Web.csproj
@@ -77,4 +77,12 @@
     <None Remove="appsettings.local.json" />
   </ItemGroup>
 
+  <Target Name="WritePublishedVersionFile" AfterTargets="Publish">
+    <WriteLinesToFile
+      File="$(PublishDir)version.txt"
+      Lines="$(InformationalVersion)"
+      Overwrite="true"
+      Encoding="UTF-8" />
+  </Target>
+
 </Project>

--- a/tests/TelegramPanel.Web.Tests/EntrypointScriptTests.cs
+++ b/tests/TelegramPanel.Web.Tests/EntrypointScriptTests.cs
@@ -129,6 +129,67 @@ public sealed class EntrypointScriptTests
         }
     }
 
+    [Fact]
+    public void Entrypoint_PrefersNewerImageOverConfirmedOlderSelfUpdate()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        var root = CreateTempDirectory();
+        try
+        {
+            var data = Path.Combine(root, "data");
+            var imageApp = Path.Combine(root, "app");
+            var current = Path.Combine(data, "app-current");
+            Directory.CreateDirectory(imageApp);
+            CreateRunnableVersion(imageApp, "1.31.38");
+            CreateRunnableVersion(current, "1.31.37");
+            File.WriteAllText(Path.Combine(current, ".telegram-panel-update-confirmed"), "{}");
+
+            var resultPath = Path.Combine(root, "started-from.txt");
+            RunEntrypoint(data, imageApp, resultPath);
+
+            Assert.Equal(Path.GetFullPath(imageApp), File.ReadAllText(resultPath).Trim());
+            Assert.False(Directory.Exists(current));
+            var obsolete = Assert.Single(Directory.GetDirectories(data, "app-obsolete-*"));
+            Assert.Equal("1.31.37", File.ReadAllText(Path.Combine(obsolete, "version.txt")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Entrypoint_PrefersNewerConfirmedSelfUpdateOverOlderImage()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        var root = CreateTempDirectory();
+        try
+        {
+            var data = Path.Combine(root, "data");
+            var imageApp = Path.Combine(root, "app");
+            var current = Path.Combine(data, "app-current");
+            Directory.CreateDirectory(imageApp);
+            CreateRunnableVersion(imageApp, "1.31.37");
+            CreateRunnableVersion(current, "1.31.38");
+            File.WriteAllText(Path.Combine(current, ".telegram-panel-update-confirmed"), "{}");
+
+            var resultPath = Path.Combine(root, "started-from.txt");
+            RunEntrypoint(data, imageApp, resultPath);
+
+            Assert.Equal(Path.GetFullPath(current), File.ReadAllText(resultPath).Trim());
+            Assert.True(Directory.Exists(current));
+            Assert.Empty(Directory.GetDirectories(data, "app-obsolete-*"));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void RunEntrypoint(string data, string imageApp, string resultPath)
     {
         var scriptPath = FindRepositoryFile(Path.Combine("docker", "entrypoint.sh"));


### PR DESCRIPTION
## 问题\nv1.31.37 通过自更新进入 /data/app-current 后，升级 Docker 镜像到 v1.31.38 重启仍优先运行旧持久化程序集。\n\n## 修复\n- 发布产物写入 version.txt。\n- 入口脚本比较镜像与持久化程序版本。\n- 镜像版本更高时归档旧 app-current 并启动镜像版本。\n- 增加双向版本优先级回归测试。\n- 更新开发发布文档。\n\n请先在 dev 完成构建和云端部署验收，再合并 main。