### PR TITLE
fix: 让新镜像覆盖旧版自更新目录

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -73,6 +73,24 @@ $right
 EOF
 }
 
+prefer_newer_image() {
+  IMAGE_VERSION="$(read_version_file "$IMAGE_VERSION_FILE")"
+  UPDATED_VERSION="$(read_version_file "$UPDATED_VERSION_FILE")"
+  if [ -n "$IMAGE_VERSION" ] && [ -n "$UPDATED_VERSION" ] \
+    && version_is_greater "$IMAGE_VERSION" "$UPDATED_VERSION"; then
+    OBSOLETE_APP_DIR="$DATA_DIR/app-obsolete-$(date +%Y%m%d%H%M%S)-$$"
+    if mv "$UPDATED_APP_DIR" "$OBSOLETE_APP_DIR"; then
+      APP_DIR="$DEFAULT_APP_DIR"
+      log "镜像版本 v$IMAGE_VERSION 高于持久化版本 v$UPDATED_VERSION，已归档旧版本并使用镜像目录"
+    else
+      APP_DIR="$DEFAULT_APP_DIR"
+      log "无法归档旧持久化版本，为避免阻塞镜像升级，使用镜像目录：$DEFAULT_APP_DIR"
+    fi
+    return 0
+  fi
+  return 1
+}
+
 mkdir -p "$DATA_DIR" "$DATA_DIR/sessions" "$DATA_DIR/logs"
 if [ ! -f "$DATA_DIR/appsettings.local.json" ]; then
   printf '{}' > "$DATA_DIR/appsettings.local.json"
@@ -84,21 +102,11 @@ if [ -f "$UPDATED_APP_DIR/$APP_ENTRY" ]; then
     APP_DIR="$DEFAULT_APP_DIR"
     log "当前为 image 更新模式，使用镜像目录：$DEFAULT_APP_DIR"
   elif [ -f "$UPDATE_CONFIRMED_MARKER" ]; then
-    IMAGE_VERSION="$(read_version_file "$IMAGE_VERSION_FILE")"
-    UPDATED_VERSION="$(read_version_file "$UPDATED_VERSION_FILE")"
     if [ "$UPDATE_MODE" = "binary" ]; then
       APP_DIR="$UPDATED_APP_DIR"
       log "当前为 binary 更新模式，使用持久化目录：$UPDATED_APP_DIR"
-    elif [ -n "$IMAGE_VERSION" ] && [ -n "$UPDATED_VERSION" ] \
-      && version_is_greater "$IMAGE_VERSION" "$UPDATED_VERSION"; then
-      OBSOLETE_APP_DIR="$DATA_DIR/app-obsolete-$(date +%Y%m%d%H%M%S)-$$"
-      if mv "$UPDATED_APP_DIR" "$OBSOLETE_APP_DIR"; then
-        APP_DIR="$DEFAULT_APP_DIR"
-        log "镜像版本 v$IMAGE_VERSION 高于持久化版本 v$UPDATED_VERSION，已归档旧版本并使用镜像目录"
-      else
-        APP_DIR="$DEFAULT_APP_DIR"
-        log "无法归档旧持久化版本，为避免阻塞镜像升级，使用镜像目录：$DEFAULT_APP_DIR"
-      fi
+    elif prefer_newer_image; then
+      :
     else
       APP_DIR="$UPDATED_APP_DIR"
     fi
@@ -127,9 +135,12 @@ if [ -f "$UPDATED_APP_DIR/$APP_ENTRY" ]; then
     fi
   elif [ -f "$UPDATED_APP_MARKER" ]; then
     # 兼容 v1.31.32 之前只写单个 marker 的更新器。
+    # 旧 marker 也必须参与镜像版本比较，否则旧的一键更新目录会永久遮住新镜像。
+    if prefer_newer_image; then
+      :
     # 若目标包已经携带新版入口脚本，说明它能在 StartAsync 后确认状态；
     # 这里先补记 attempted，连“程序集加载失败、尚未进入 Program”的情况也能在下次启动回滚。
-    if [ -f "$UPDATED_APP_DIR/self-update/entrypoint.sh" ]; then
+    elif [ -f "$UPDATED_APP_DIR/self-update/entrypoint.sh" ]; then
       if cp "$UPDATED_APP_MARKER" "$UPDATE_ATTEMPTED_MARKER"; then
         APP_DIR="$UPDATED_APP_DIR"
         log "已将旧版更新 marker 迁移为 attempted 状态"

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -49,6 +49,7 @@ ghcr.io/moeacgx/telegram-panel:dev-latest
 
 - 镜像版本更高时，优先启动镜像版本，并将旧的持久化程序目录归档为 `/data/app-obsolete-*`；
 - 持久化自更新版本更高时，继续优先使用已确认启动成功的自更新版本；
+- 该比较同时适用于新版确认标记和旧版 `.telegram-panel-self-update` 标记，避免历史自更新目录永久遮住新镜像；
 - 旧版本包没有 `version.txt` 时保持兼容行为，仍按启动确认标记选择目录。
 
 可通过 `.env` 的 `TP_UPDATE_MODE` 明确选择 `auto`、`image` 或 `binary`。该策略同时注入入口脚本和应用配置，避免 UI 显示的更新方式与容器实际启动目录不一致。

--- a/tests/TelegramPanel.Web.Tests/EntrypointScriptTests.cs
+++ b/tests/TelegramPanel.Web.Tests/EntrypointScriptTests.cs
@@ -165,6 +165,36 @@ public sealed class EntrypointScriptTests
     }
 
     [Fact]
+    public void Entrypoint_PrefersNewerImageOverLegacyOlderSelfUpdate()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        var root = CreateTempDirectory();
+        try
+        {
+            var data = Path.Combine(root, "data");
+            var imageApp = Path.Combine(root, "app");
+            var current = Path.Combine(data, "app-current");
+            CreateRunnableVersion(imageApp, "1.31.38");
+            CreateRunnableVersion(current, "1.31.37");
+            File.WriteAllText(Path.Combine(current, ".telegram-panel-self-update"), "{}");
+
+            var resultPath = Path.Combine(root, "started-from.txt");
+            RunEntrypoint(data, imageApp, resultPath);
+
+            Assert.Equal(Path.GetFullPath(imageApp), File.ReadAllText(resultPath).Trim());
+            Assert.False(Directory.Exists(current));
+            var obsolete = Assert.Single(Directory.GetDirectories(data, "app-obsolete-*"));
+            Assert.Equal("1.31.37", File.ReadAllText(Path.Combine(obsolete, "version.txt")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Entrypoint_PrefersNewerConfirmedSelfUpdateOverOlderImage()
     {
         if (!OperatingSystem.IsLinux())


### PR DESCRIPTION
## 变更\n- 统一 confirmed 与 legacy marker 的镜像版本比较逻辑\n- 镜像版本更高时归档旧的 /data/app-current\n- 增加 legacy 旧版本回归测试\n- 更新开发发布流程文档\n\n## 验证\n- Windows .NET 入口测试编译通过（Linux 断言在 Windows 上跳过）\n- Alpine Linux sh 语法及 legacy 归档场景通过\n\n目标分支：dev；云端部署将在合入后执行。