### PR TITLE
ci: 部署时选择更新模式并校验实际版本

### DIFF
--- a/.github/workflows/deploy-telegram-panel.yml
+++ b/.github/workflows/deploy-telegram-panel.yml
@@ -7,6 +7,10 @@ on:
         description: Docker image to deploy
         required: true
         default: ghcr.io/moeacgx/telegram-panel:dev-latest
+      update_mode:
+        description: Update source mode written to the cloud data volume
+        required: true
+        default: auto
 
 jobs:
   deploy:
@@ -20,6 +24,7 @@ jobs:
           port: ${{ secrets.TELEGRAM_PANEL_PROD_PORT }}
           username: ${{ secrets.TELEGRAM_PANEL_PROD_USER }}
           password: ${{ secrets.TELEGRAM_PANEL_PROD_PASSWORD }}
+          envs: DEPLOY_UPDATE_MODE
           command_timeout: 15m
           script: |
             set -euo pipefail
@@ -28,6 +33,15 @@ jobs:
             DATA_DIR="$APP_DIR/docker-data"
             BACKUP_DIR="$APP_DIR/backups"
             IMAGE="${{ github.event.inputs.image }}"
+            UPDATE_MODE="${DEPLOY_UPDATE_MODE:-auto}"
+
+            case "$UPDATE_MODE" in
+              auto|image|binary) ;;
+              *)
+                echo "Unsupported update mode: $UPDATE_MODE" >&2
+                exit 1
+                ;;
+            esac
 
             test -d "$APP_DIR"
             test -f "$APP_DIR/docker-compose.yml"
@@ -60,6 +74,8 @@ jobs:
               printf 'TP_IMAGE=%s\n' "$IMAGE" > .env
             fi
 
+            printf '%s\n' "$UPDATE_MODE" > "$DATA_DIR/update-mode.txt"
+
             docker pull "$IMAGE"
             if [ -f docker-compose.warp.yml ]; then
               docker compose \
@@ -74,4 +90,12 @@ jobs:
             docker ps --filter name=telegram-panel --format 'container={{.Names}} image={{.Image}} status={{.Status}}'
             docker logs --tail 120 telegram-panel
             curl -fsS -I http://127.0.0.1:5000/ui/dashboard
-            curl -fsS http://127.0.0.1:5000/api/panel/auth/me
+            VERSION_RESPONSE="$(curl -fsS http://127.0.0.1:5000/api/panel/auth/me)"
+            printf '%s\n' "$VERSION_RESPONSE"
+            EXPECTED_VERSION="$(docker run --rm --entrypoint sh "$IMAGE" -c 'cat /app/version.txt')"
+            if ! printf '%s' "$VERSION_RESPONSE" | grep -Fq "\"version\":\"$EXPECTED_VERSION\""; then
+              echo "运行版本与镜像版本不一致：镜像=$EXPECTED_VERSION 响应=$VERSION_RESPONSE" >&2
+              exit 1
+            fi
+        env:
+          DEPLOY_UPDATE_MODE: ${{ github.event.inputs.update_mode }}

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -37,13 +37,15 @@ ghcr.io/moeacgx/telegram-panel:dev-latest
 
 ### 3. 部署云端测试环境
 
-在 GitHub Actions 手动运行 `Deploy Telegram Panel`，选择 `dev` 分支，镜像使用对应 `dev-latest` 或带 SHA 的不可变标签。工作流会：
+在 GitHub Actions 手动运行 `Deploy Telegram Panel`，选择 `dev` 分支，镜像使用对应 `dev-latest` 或带 SHA 的不可变标签，并在 `update_mode` 中选择 `auto`、`image` 或 `binary`。工作流会：
 
 1. 在云端 `/home/docker/Telegram-Panel` 拉取 `dev`；
 2. 备份 `docker-data` 中的 SQLite 数据文件；
 3. 拉取镜像并保留 `docker-compose.warp.yml` 等 override；
 4. 重建 `telegram-panel` 容器；
 5. 检查容器状态、最近日志、`/ui/dashboard` 和 `/api/panel/auth/me`。
+
+部署脚本会把选择的更新模式写入 `/data/update-mode.txt`，并比较镜像 `/app/version.txt` 与 `/api/panel/auth/me` 的实际运行版本；两者不一致时部署失败，避免工作流表面成功但容器仍运行旧的持久化程序。
 
 入口脚本会比较镜像内的 `version.txt` 与持久化自更新目录 `/data/app-current/version.txt`：
 


### PR DESCRIPTION
## 变更\n- Deploy Telegram Panel 增加 auto/image/binary 更新模式输入\n- 部署时将模式写入云端 /data/update-mode.txt\n- 部署后比较镜像 /app/version.txt 与 /api/panel/auth/me 实际运行版本\n- 更新开发发布文档\n\n## 背景\n本次 dev 镜像已成功构建并部署，但云端仍运行旧持久化程序；新增校验避免部署工作流误报成功。\n\n本 PR 合入后将使用 image 模式重新部署 dev-latest。