### PR TITLE
release: v1.31.40

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release tag version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PROJECT_VERSION="$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n 1)"
+          if [[ -z "$PROJECT_VERSION" || "$PROJECT_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Tag version $TAG_VERSION does not match Directory.Build.props version $PROJECT_VERSION" >&2
+            exit 1
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,23 @@ jobs:
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout source at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.vars.outputs.tag }}
+
+      - name: Validate release tag version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.vars.outputs.tag }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          PROJECT_VERSION="$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n 1)"
+          if [[ -z "$PROJECT_VERSION" || "$PROJECT_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Tag version $TAG_VERSION does not match Directory.Build.props version $PROJECT_VERSION" >&2
+            exit 1
+          fi
+
   build-linux:
     needs: prepare
     runs-on: ubuntu-latest

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,12 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.38</Version>
-    <AssemblyVersion>1.31.38.0</AssemblyVersion>
-    <FileVersion>1.31.38.0</FileVersion>
-    <InformationalVersion>1.31.38</InformationalVersion>
+    <Version>1.31.40</Version>
+    <AssemblyVersion>1.31.40.0</AssemblyVersion>
+    <FileVersion>1.31.40.0</FileVersion>
+    <InformationalVersion>1.31.40</InformationalVersion>
+    <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <!-- 项目元信息 -->
     <Authors>Telegram Panel Contributors</Authors>

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -82,6 +82,13 @@ ghcr.io/moeacgx/telegram-panel:dev-latest
 
 `main` 合并后会构建 `latest` 和多架构镜像；若需要正式版本，再按现有 Release 工作流创建 tag。正式发布不得反向替代 `dev` 验收。
 
+创建正式 tag 前，必须先把 `Directory.Build.props` 中的 `Version`、`AssemblyVersion`、
+`FileVersion` 和 `InformationalVersion` 更新为目标版本。Docker tag 构建和 Release 工作流
+都会校验 `vX.Y.Z` 与项目 `Version` 完全一致；不一致时应停止发布，禁止生成“文件名是新
+版本、包内二进制仍显示旧版本”的资产。成功判据是 Release ZIP 内 `version.txt`、运行时
+`/api/panel/auth/me` 和 tag 三者一致。回滚时删除尚未发布的错误 tag；已经公开的错误版本
+不得覆盖重发，应递增补丁版本重新发布。
+
 ### 5. 清理分支
 
 合并确认后执行清理：

--- a/tests/TelegramPanel.Web.Tests/ReleaseVersionContractTests.cs
+++ b/tests/TelegramPanel.Web.Tests/ReleaseVersionContractTests.cs
@@ -1,0 +1,68 @@
+using System.Xml.Linq;
+using Xunit;
+
+namespace TelegramPanel.Web.Tests;
+
+public sealed class ReleaseVersionContractTests
+{
+    [Fact]
+    public void 项目版本字段保持一致且发布包写入信息版本()
+    {
+        var root = FindRepositoryRoot();
+        var props = XDocument.Load(Path.Combine(root, "Directory.Build.props"));
+        var values = new[]
+        {
+            ReadProperty(props, "Version"),
+            ReadProperty(props, "InformationalVersion"),
+            RemoveRevisionComponent(ReadProperty(props, "AssemblyVersion")),
+            RemoveRevisionComponent(ReadProperty(props, "FileVersion"))
+        };
+
+        Assert.All(values, value => Assert.Equal(values[0], value));
+        Assert.Equal(
+            "false",
+            ReadProperty(props, "IncludeSourceRevisionInInformationalVersion"));
+
+        var webProject = File.ReadAllText(
+            Path.Combine(root, "src", "TelegramPanel.Web", "TelegramPanel.Web.csproj"));
+        Assert.Contains("Lines=\"$(InformationalVersion)\"", webProject, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("docker.yml")]
+    [InlineData("release.yml")]
+    public void 正式标签工作流校验项目版本(string workflowName)
+    {
+        var root = FindRepositoryRoot();
+        var workflow = File.ReadAllText(
+            Path.Combine(root, ".github", "workflows", workflowName));
+
+        Assert.Contains("Validate release tag version", workflow, StringComparison.Ordinal);
+        Assert.Contains("Directory.Build.props", workflow, StringComparison.Ordinal);
+        Assert.Contains("PROJECT_VERSION", workflow, StringComparison.Ordinal);
+        Assert.Contains("TAG_VERSION", workflow, StringComparison.Ordinal);
+    }
+
+    private static string ReadProperty(XDocument document, string propertyName) =>
+        document.Descendants(propertyName).Select(x => x.Value.Trim()).FirstOrDefault()
+        ?? throw new InvalidOperationException($"Directory.Build.props 缺少 {propertyName}");
+
+    private static string RemoveRevisionComponent(string version) =>
+        version.EndsWith(".0", StringComparison.Ordinal) ? version[..^2] : version;
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory != null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Directory.Build.props"))
+                && Directory.Exists(Path.Combine(directory.FullName, ".github", "workflows")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException("未找到仓库根目录");
+    }
+}


### PR DESCRIPTION
## 发布内容\n\n修复容器内二进制更新后界面仍显示旧版本的问题。根因是 Release 包内 InformationalVersion 沿用 1.31.38 并追加 Git SHA，并非入口优先运行镜像。\n\n## 云端 dev 验收\n\n- dev 合并提交：5da5917b32e098ae36572216656dd6dbad6d58e9\n- 镜像：ghcr.io/moeacgx/telegram-panel:dev-latest\n- Docker 构建：通过\n- 容器状态：已启动\n- /ui/dashboard：HTTP 200\n- /api/panel/auth/me：version=1.31.40\n\n## 正式发布后验收\n\n创建 v1.31.40 后检查 Release ZIP 内 version.txt，并切回 binary 模式验证 /data/app-current。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Updated the project version to 1.31.40.
  * Release and Docker builds now verify that tags match the project version before publishing.
  * Version information is kept consistent across release packages and runtime displays.

* **Documentation**
  * Clarified release, validation, success criteria, and rollback procedures.

* **Tests**
  * Added automated checks for version consistency and release workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->