### PR TITLE
fix: 修复中文 Release Notes 生成脚本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,9 +243,12 @@ jobs:
                 sha="${item##*$'\t'}"
                 type="other"
                 title="$subject"
-                if [[ "$subject" =~ ^([a-zA-Z]+)(\([^)]*\))?!?:[[:space:]]*(.+)$ ]]; then
-                  raw_type="${BASH_REMATCH[1],,}"
-                  title="${BASH_REMATCH[3]}"
+                if [[ "$subject" == *:* ]]; then
+                  prefix="${subject%%:*}"
+                  title="${subject#*:}"
+                  raw_type="${prefix%%(*}"
+                  raw_type="${raw_type%!}"
+                  raw_type="${raw_type,,}"
                   case "$raw_type" in feat|fix|perf|docs|refactor|test|build|ci|release|chore) type="$raw_type" ;; *) type="other" ;; esac
                 fi
                 title="$(echo "$title" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.48</Version>
-    <AssemblyVersion>1.31.48.0</AssemblyVersion>
-    <FileVersion>1.31.48.0</FileVersion>
-    <InformationalVersion>1.31.48</InformationalVersion>
+    <Version>1.31.49</Version>
+    <AssemblyVersion>1.31.49.0</AssemblyVersion>
+    <FileVersion>1.31.49.0</FileVersion>
+    <InformationalVersion>1.31.49</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 


### PR DESCRIPTION
## 本次变更\n- 修复 Release workflow 中 bash 正则导致的生成脚本语法错误\n- 版本递增到 v1.31.49，避免覆盖已失败的 v1.31.48 tag\n\n## 验证\n- python YAML parse .github/workflows/release.yml\n- dotnet build TelegramPanel.sln -c Release --no-restore\n- mkdocs build --strict\n\n## 说明\n- v1.31.48 tag 的 Release workflow 已失败，不覆盖重发，改用 v1.31.49。