### PR TITLE
feat: 在线设备显示 API 来源说明

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -303,6 +303,10 @@ export interface TelegramAuthorization {
   createdAtUtc?: string | null
   lastActiveAtUtc?: string | null
   title: string
+  apiFamily: string
+  apiDisplayName: string
+  apiDescription: string
+  deviceDisplayName: string
 }
 
 export interface AccountChatMembership {

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -600,15 +600,24 @@
           <el-table-column label="当前" width="64" align="center">
             <template #default="{ row }"><el-tag :type="row.current ? 'success' : 'info'" size="small">{{ row.current ? '是' : '否' }}</el-tag></template>
           </el-table-column>
-          <el-table-column label="应用/设备" min-width="260">
+          <el-table-column label="应用 / API / 设备" min-width="340">
             <template #default="{ row }">
-              <div class="device-title">{{ row.title }}</div>
-              <div class="cell-sub device-meta">ApiId={{ row.apiId }} {{ row.appVersion || '' }}</div>
+              <div class="device-title">{{ row.appName || 'UnknownApp' }} - {{ row.deviceDisplayName || row.deviceModel || 'UnknownDevice' }}</div>
+              <div class="device-api-line">
+                <el-tag size="small" effect="plain">ApiId={{ row.apiId }}</el-tag>
+                <el-tag size="small" type="info" effect="plain">{{ row.apiFamily || '未知 API' }}</el-tag>
+              </div>
+              <div class="cell-sub device-meta">应用/平台：{{ row.apiDisplayName || [row.appName, row.platform].filter(Boolean).join(' / ') || '-' }}</div>
+              <div class="cell-sub device-meta">版本：{{ row.appVersion || '-' }}</div>
+              <el-tooltip v-if="row.apiDescription" :content="row.apiDescription" placement="top" effect="light">
+                <el-tag class="device-help-tag" size="small" type="warning" effect="plain">说明</el-tag>
+              </el-tooltip>
             </template>
           </el-table-column>
-          <el-table-column label="系统" min-width="180">
+          <el-table-column label="设备画像 / 系统" min-width="220">
             <template #default="{ row }">
-              <span class="device-text">{{ [row.platform, row.systemVersion].filter(Boolean).join(' ') || '-' }}</span>
+              <div class="device-text">{{ row.deviceDisplayName || row.deviceModel || '-' }}</div>
+              <div class="cell-sub device-meta">{{ [row.platform, row.systemVersion].filter(Boolean).join(' ') || '-' }}</div>
             </template>
           </el-table-column>
           <el-table-column label="IP/地区" min-width="220">
@@ -2192,6 +2201,18 @@ onMounted(async () => {
   word-break: break-word;
   white-space: normal;
   line-height: 1.35;
+}
+
+.device-api-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 4px;
+}
+
+.device-help-tag {
+  margin-top: 5px;
+  cursor: help;
 }
 
 .message-item {

--- a/src/TelegramPanel.Core/Models/TelegramAuthorizationInfo.cs
+++ b/src/TelegramPanel.Core/Models/TelegramAuthorizationInfo.cs
@@ -19,14 +19,34 @@ public record TelegramAuthorizationInfo(
     DateTime? LastActiveAtUtc
 )
 {
-    public string Title
+    public string ApiFamily => ApiId switch
+    {
+        6 => "官方 Android API",
+        2834 => "官方 macOS API",
+        2040 => "官方 Desktop API",
+        _ => "自建/第三方 API"
+    };
+
+    public string ApiDisplayName
     {
         get
         {
-            var app = string.IsNullOrWhiteSpace(AppName) ? "UnknownApp" : AppName;
-            var device = string.IsNullOrWhiteSpace(DeviceModel) ? "UnknownDevice" : DeviceModel;
-            return $"{app} - {device}";
+            var app = string.IsNullOrWhiteSpace(AppName) ? "UnknownApp" : AppName.Trim();
+            var platform = string.IsNullOrWhiteSpace(Platform) ? null : Platform.Trim();
+            return platform is null ? app : $"{app} / {platform}";
         }
     }
+
+    public string DeviceDisplayName => string.IsNullOrWhiteSpace(DeviceModel) ? "UnknownDevice" : DeviceModel.Trim();
+
+    public string Title => $"{(string.IsNullOrWhiteSpace(AppName) ? "UnknownApp" : AppName.Trim())} - {DeviceDisplayName}";
+
+    public string ApiDescription => ApiId switch
+    {
+        6 => "Telegram 会显示为 Telegram Android；设备画像应使用 Android 手机与 Android 系统。",
+        2834 => "Telegram 会显示为 Telegram macOS；设备画像应使用 Mac 设备与 macOS 系统。",
+        2040 => "Telegram 会显示为 Telegram Desktop；设备画像应使用 PC 与 Windows/Linux 系统。",
+        _ => "应用名和平台来自 my.telegram.org 上该 ApiId 的注册信息；面板只能控制设备型号、系统版本和 App 版本。"
+    };
 }
 


### PR DESCRIPTION
## 本次变更
- 在线设备接口增加 API 族、应用/平台显示名、设备显示名和说明文本
- 在线设备弹窗拆分展示应用/API/设备画像，明确 ApiId 对应官方 Android/macOS/Desktop 或自建 API
- 自建 API 说明提示：应用名和平台来自 my.telegram.org 注册信息，面板只能控制设备型号、系统版本和 App 版本

## 验证
- dotnet build TelegramPanel.sln -c Release --no-restore
- pnpm --dir frontend run build
- pnpm --dir frontend test

## 说明
- 这是展示增强，不改变 Telegram 授权创建逻辑。