### PR TITLE
fix: 修复 Release Notes emoji 补齐

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,10 +230,58 @@ jobs:
           {
             echo "## 本次版本主要更新"
             echo
-            NOTES_BLOCK="$(git log --no-merges --format='%B%n---END-COMMIT---' "$RANGE" | python3 -c 'exec("""import sys\ntext=sys.stdin.read()\nblocks=[]\nfor commit in text.split(\"---END-COMMIT---\"):\n    lines=commit.splitlines()\n    for i,line in enumerate(lines):\n        if line.strip()==\"## 本次版本主要更新\":\n            picked=[]\n            for body_line in lines[i+1:]:\n                if body_line.startswith(\"## \"):\n                    break\n                picked.append(body_line)\n            block=\"\\n\".join(picked).strip()\n            if block:\n                blocks.append(block)\n            break\nprint(\"\\n\\n\".join(blocks))\n""")')"
+            NOTES_BLOCK="$(
+              python3 - "$RANGE" <<'PY'
+          import subprocess
+          import sys
+
+          range_ref = sys.argv[1]
+          text = subprocess.check_output(
+              ["git", "log", "--no-merges", "--format=%B%n---END-COMMIT---", range_ref],
+              text=True,
+          )
+          section_icons = {
+              "新增功能": "✨ 新增功能",
+              "修复问题": "🐛 修复问题",
+              "性能优化": "⚡ 性能优化",
+              "文档更新": "📚 文档更新",
+              "代码重构": "🧹 代码重构",
+              "测试改进": "✅ 测试改进",
+              "构建发布": "📦 构建发布",
+              "CI/CD": "🔧 CI/CD",
+              "版本发布": "🚀 版本发布",
+              "其他变更": "🧩 其他变更",
+          }
+
+          def normalize_heading(line: str) -> str:
+              if not line.startswith("### "):
+                  return line
+              title = line[4:].strip()
+              if title in section_icons:
+                  return f"### {section_icons[title]}"
+              return line
+
+          blocks = []
+          for commit in text.split("---END-COMMIT---"):
+              lines = commit.splitlines()
+              for i, line in enumerate(lines):
+                  if line.strip() == "## 本次版本主要更新":
+                      picked = []
+                      for body_line in lines[i + 1:]:
+                          if body_line.startswith("## "):
+                              break
+                          picked.append(normalize_heading(body_line))
+                      block = "\n".join(picked).strip()
+                      if block:
+                          blocks.append(block)
+                      break
+          print("\n\n".join(blocks))
+          PY
+            )"
             if [[ -n "$NOTES_BLOCK" ]]; then
               printf '%s\n\n' "$NOTES_BLOCK"
             else
+              mapfile -t COMMITS < <(git log --no-merges --format='%s%x09%h' "$RANGE")
               declare -A SECTIONS=( [feat]="✨ 新增功能" [fix]="🐛 修复问题" [perf]="⚡ 性能优化" [docs]="📚 文档更新" [refactor]="🧹 代码重构" [test]="✅ 测试改进" [build]="📦 构建发布" [ci]="🔧 CI/CD" [release]="🚀 版本发布" [chore]="🧩 其他变更" [other]="🧩 其他变更" )
               TYPES=(feat fix perf docs refactor test build ci release chore other)
               declare -A BUCKETS
@@ -264,7 +312,7 @@ jobs:
               done
             fi
             if [[ -n "$PREVIOUS_TAG" ]]; then
-              echo "完整变更记录： https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${TAG}"
+              echo "🔗 完整变更记录： https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${TAG}"
               echo
             fi
             echo "> [!WARNING]"
@@ -272,22 +320,22 @@ jobs:
             echo "> 先停止容器并备份宿主机 \`docker-data\` 与容器内 \`/app\`；本版可以恢复仍存在的旧库，"
             echo "> 但无法重新生成已经被旧更新器或人工操作删除的文件。"
             echo
-            echo "## 部署与更新"
+            echo "## 🚀 部署与更新"
             echo
-            echo "### 1. Docker 镜像"
+            echo "### 🐳 1. Docker 镜像"
             echo "拉取对应 tag 的镜像："
             echo
             echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository }}:${TAG}"
             echo '```'
             echo
-            echo "### 2. 面板内一键更新（Docker）"
+            echo "### 🔄 2. 面板内一键更新（Docker）"
             echo "路径：\`左上角版本号 -> 版本信息弹窗 -> 一键更新并重启\`"
             echo
-            echo "### 3. Windows 桌面版"
+            echo "### 🖥️ 3. Windows 桌面版"
             echo "下载 \`telegram-panel-${TAG}-windows-x64-setup.exe\` 安装包。"
             echo
-            echo "## 应用内更新资产"
+            echo "## 📦 应用内更新资产"
             echo
             echo "- \`telegram-panel-${TAG}-linux-x64.zip\`"
             echo "- \`telegram-panel-${TAG}-linux-arm64.zip\`"

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -96,11 +96,11 @@ Docker PR 工作流必须覆盖会改变镜像内容或运行版本的路径；�
 Release 正文由 `.github/workflows/release.yml` 的 `Generate Chinese release notes` 步骤生成，不再直接使用 GitHub 默认的英文 `What's Changed`。生成规则：
 
 - 正文顶部固定为 `## 本次版本主要更新`；变更列表在部署说明之前；
-- 如果 release/squash 提交正文中包含 `## 本次版本主要更新` 小节，工作流会优先原样提取该小节内容，直到下一个二级标题为止；
+- 如果 release/squash 提交正文中包含 `## 本次版本主要更新` 小节，工作流会优先提取该小节内容，直到下一个二级标题为止，并为 `### 新增功能`、`### 修复问题`、`### 文档更新` 等已知分类标题补齐 emoji；
 - 如果提交正文没有该小节，工作流才回退到 commit 标题分类生成；
-- conventional commit 类型会映射到中文分类，如 `feat` → `新增功能`、`fix` → `修复问题`、`release` → `版本发布`；
+- conventional commit 类型会映射到带 emoji 的中文分类，如 `feat` → `✨ 新增功能`、`fix` → `🐛 修复问题`、`release` → `🚀 版本发布`；
 - 回退生成的列表项会去掉 `fix:`、`feat:` 等英文前缀，只保留中文或可读标题与短 SHA；
-- 底部保留 GitHub compare 链接，标题为 `完整变更记录`。
+- 底部保留 GitHub compare 链接，标题为 `🔗 完整变更记录`。
 
 发布 PR 的 squash 正文必须包含面向用户的 `## 本次版本主要更新` 小节，示例：
 


### PR DESCRIPTION
## 本次版本主要更新

### 🐛 修复问题

- 修复 Release workflow 在优先提取发布正文时不会给已有中文分类标题补齐 emoji 的问题。
- 补回发布说明中的 `🔗 完整变更记录`、`🚀 部署与更新`、`🐳 Docker 镜像`、`🔄 面板内一键更新`、`🖥️ Windows 桌面版`、`📦 应用内更新资产` 标题。

## 验证

- 已用 v1.31.50 的发布正文生成脚本抽样生成 `.artifacts/release-notes-test.md`，确认包含 `### 🐛 修复问题`、`### 📚 文档更新`、`🔗 完整变更记录`、`## 🚀 部署与更新`、`## 📦 应用内更新资产`。
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- `mkdocs build --strict`
- 已直接修正当前 v1.31.50 Release 正文。