### PR TITLE
fix: 修复 R2 存储桶备份上传

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.50</Version>
-    <AssemblyVersion>1.31.50.0</AssemblyVersion>
-    <FileVersion>1.31.50.0</FileVersion>
-    <InformationalVersion>1.31.50</InformationalVersion>
+    <Version>1.31.51</Version>
+    <AssemblyVersion>1.31.51.0</AssemblyVersion>
+    <FileVersion>1.31.51.0</FileVersion>
+    <InformationalVersion>1.31.51</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -4,6 +4,8 @@
 
 也可以在 **系统设置 → 存储桶备份** 配置对象存储上传 URL，更新前点击“立即备份”把数据库、配置、后台凭据和 sessions 上传到 S3/R2/OSS/COS 等存储桶。
 
+Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升级到包含该修复的版本后重试；面板会对 R2 上传自动发送 `x-amz-content-sha256: UNSIGNED-PAYLOAD`。
+
 <a id="bucket-backup-restore"></a>
 
 ## 从存储桶备份恢复

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -175,7 +175,7 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 https://bucket.example.com/telegram-panel/tp-{timestamp}.zip?X-Amz-Signature=...
 ```
 
-前置条件是对象存储 URL 在面板容器内可访问，且签名允许对应 HTTP 方法上传 `application/zip`。成功判据是系统设置点击“立即备份”返回成功，存储桶出现 ZIP，解压后能看到 `telegram-panel.db` 和 `sessions/`。失败时先检查 URL 是否过期、方法是否匹配、容器 DNS/网络是否可达，以及 Authorization Header 是否需要清空后重填。回滚方式是关闭 `BucketBackup:Enabled` 或清空上传 URL；已上传对象需要在存储桶侧按生命周期或人工删除。
+前置条件是对象存储 URL 在面板容器内可访问，且签名允许对应 HTTP 方法上传 `application/zip`。Cloudflare R2 预签名 `PUT` URL 使用 AWS Signature V4 时，面板会在请求中自动补充 `x-amz-content-sha256: UNSIGNED-PAYLOAD`；如果生成 URL 时已经把 `X-Amz-Content-Sha256` 写入查询参数，面板不会覆盖该签名约束。成功判据是系统设置点击“立即备份”返回成功，存储桶出现 ZIP，解压后能看到 `telegram-panel.db` 和 `sessions/`。失败时先检查 URL 是否过期、方法是否匹配、容器 DNS/网络是否可达，以及 Authorization Header 是否需要清空后重填。回滚方式是关闭 `BucketBackup:Enabled` 或清空上传 URL；已上传对象需要在存储桶侧按生命周期或人工删除。
 
 当前后台面板不提供“导入备份恢复”入口，也不支持运行中覆盖数据。需要恢复时，先下载备份 ZIP，停机替换持久化数据目录，再重启验收；步骤见[从存储桶备份恢复](../getting-started/update.md#bucket-backup-restore)。
 

--- a/src/TelegramPanel.Web/Services/BucketBackupService.cs
+++ b/src/TelegramPanel.Web/Services/BucketBackupService.cs
@@ -12,6 +12,12 @@ public sealed class BucketBackupOptions
     public int TimeoutSeconds { get; set; } = 300;
 }
 
+internal static class BucketBackupS3Headers
+{
+    public const string ContentSha256 = "x-amz-content-sha256";
+    public const string UnsignedPayload = "UNSIGNED-PAYLOAD";
+}
+
 public sealed record BucketBackupSettingsDto(bool Enabled, string UploadUrl, string Method, bool HasAuthorizationHeader, int TimeoutSeconds);
 public sealed record SaveBucketBackupSettingsDto(bool Enabled, string? UploadUrl, string? Method, string? AuthorizationHeader, bool ClearAuthorizationHeader, int TimeoutSeconds);
 public sealed record BucketBackupResultDto(bool Success, string Message, string? Url, long? SizeBytes, DateTimeOffset CompletedAtUtc);
@@ -77,6 +83,7 @@ public sealed class BucketBackupService
             request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
             if (!string.IsNullOrWhiteSpace(options.AuthorizationHeader))
                 request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationHeader.Trim());
+            AddS3ContentSha256HeaderIfNeeded(request, uri);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(timeout));
@@ -162,6 +169,53 @@ public sealed class BucketBackupService
         string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase) ? "POST" : "PUT";
 
     private static int NormalizeTimeout(int timeoutSeconds) => Math.Clamp(timeoutSeconds <= 0 ? 300 : timeoutSeconds, 30, 1800);
+
+    internal static void AddS3ContentSha256HeaderIfNeeded(HttpRequestMessage request, Uri uri)
+    {
+        if (!string.Equals(request.Method.Method, "PUT", StringComparison.OrdinalIgnoreCase)
+            || request.Headers.Contains(BucketBackupS3Headers.ContentSha256))
+            return;
+
+        if (!HostLooksLikeCloudflareR2(uri.Host))
+            return;
+
+        var contentSha256 = TryGetQueryValue(uri, "X-Amz-Content-Sha256");
+        if (string.IsNullOrWhiteSpace(contentSha256))
+            contentSha256 = BucketBackupS3Headers.UnsignedPayload;
+
+        request.Headers.TryAddWithoutValidation(
+            BucketBackupS3Headers.ContentSha256,
+            contentSha256);
+    }
+
+    private static bool HostLooksLikeCloudflareR2(string host) =>
+        host.EndsWith(".r2.cloudflarestorage.com", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(host, "r2.cloudflarestorage.com", StringComparison.OrdinalIgnoreCase);
+
+
+    private static string? TryGetQueryValue(Uri uri, string name)
+    {
+        var query = uri.Query;
+        if (string.IsNullOrEmpty(query))
+            return null;
+
+        if (query[0] == '?')
+            query = query[1..];
+
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = pair.IndexOf('=', StringComparison.Ordinal);
+            var rawName = separator >= 0 ? pair[..separator] : pair;
+            if (!string.Equals(Uri.UnescapeDataString(rawName), name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return separator >= 0
+                ? Uri.UnescapeDataString(pair[(separator + 1)..])
+                : string.Empty;
+        }
+
+        return null;
+    }
 
     private static BucketBackupResultDto Fail(string message) => new(false, message, null, null, DateTimeOffset.UtcNow);
 

--- a/tests/TelegramPanel.Web.Tests/BucketBackupServiceTests.cs
+++ b/tests/TelegramPanel.Web.Tests/BucketBackupServiceTests.cs
@@ -1,0 +1,202 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TelegramPanel.Web.Services;
+using Xunit;
+
+namespace TelegramPanel.Web.Tests;
+
+public sealed class BucketBackupServiceTests
+{
+    [Fact]
+    public async Task RunAsync_AddsUnsignedPayloadHeaderForR2PutUpload()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var databasePath = Path.Combine(root, "telegram-panel.db");
+            await File.WriteAllTextAsync(databasePath, "db");
+
+            var handler = new CapturingHandler();
+            var service = CreateService(
+                root,
+                databasePath,
+                handler,
+                new BucketBackupOptions
+                {
+                    Enabled = true,
+                    UploadUrl = "https://example.r2.cloudflarestorage.com/backups/tp.zip",
+                    Method = "PUT",
+                    TimeoutSeconds = 30
+                });
+
+            var result = await service.RunAsync();
+
+            Assert.True(result.Success, result.Message);
+            Assert.Equal(HttpMethod.Put, handler.Method);
+            Assert.Equal("application/zip", handler.ContentType);
+            Assert.True(handler.SawUnsignedPayloadHeader, handler.FailureMessage);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("https://example.r2.cloudflarestorage.com/backups/tp.zip")]
+    [InlineData("https://example.r2.cloudflarestorage.com/backups/tp.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test&X-Amz-Signature=abc")]
+    public void AddS3ContentSha256HeaderIfNeeded_AddsUnsignedPayloadForR2Put(string url)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, url);
+
+        BucketBackupService.AddS3ContentSha256HeaderIfNeeded(request, request.RequestUri!);
+
+        Assert.True(request.Headers.TryGetValues(BucketBackupS3Headers.ContentSha256, out var values));
+        Assert.Equal(BucketBackupS3Headers.UnsignedPayload, Assert.Single(values));
+    }
+
+    [Fact]
+    public void AddS3ContentSha256HeaderIfNeeded_UsesSignedContentSha256QueryOnR2()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            "https://example.r2.cloudflarestorage.com/backups/tp.zip?X-Amz-Content-Sha256=abc123");
+
+        BucketBackupService.AddS3ContentSha256HeaderIfNeeded(request, request.RequestUri!);
+
+        Assert.True(request.Headers.TryGetValues(BucketBackupS3Headers.ContentSha256, out var values));
+        Assert.Equal("abc123", Assert.Single(values));
+    }
+
+    [Fact]
+    public void AddS3ContentSha256HeaderIfNeeded_DoesNotAffectPlainPutUrl()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://backup.example.com/tp.zip");
+
+        BucketBackupService.AddS3ContentSha256HeaderIfNeeded(request, request.RequestUri!);
+
+        Assert.False(request.Headers.Contains(BucketBackupS3Headers.ContentSha256));
+    }
+
+    [Fact]
+    public void AddS3ContentSha256HeaderIfNeeded_DoesNotAffectPost()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.r2.cloudflarestorage.com/backups/tp.zip");
+
+        BucketBackupService.AddS3ContentSha256HeaderIfNeeded(request, request.RequestUri!);
+
+        Assert.False(request.Headers.Contains(BucketBackupS3Headers.ContentSha256));
+    }
+
+    private static BucketBackupService CreateService(
+        string root,
+        string databasePath,
+        HttpMessageHandler handler,
+        BucketBackupOptions options)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={databasePath}",
+                ["AdminAuth:CredentialsPath"] = Path.Combine(root, "admin_auth.json"),
+                ["Telegram:SessionsPath"] = Path.Combine(root, "sessions")
+            })
+            .Build();
+
+        return new BucketBackupService(
+            new TestHttpClientFactory(handler),
+            configuration,
+            new TestWebHostEnvironment(root),
+            new TestOptionsMonitor<BucketBackupOptions>(options),
+            NullLogger<BucketBackupService>.Instance);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "telegram-panel-bucket-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // 测试清理失败不应掩盖断言结果。
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpMethod? Method { get; private set; }
+        public string? ContentType { get; private set; }
+        public bool SawUnsignedPayloadHeader { get; private set; }
+        public string? FailureMessage { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Method = request.Method;
+            ContentType = request.Content?.Headers.ContentType?.MediaType;
+            SawUnsignedPayloadHeader = request.Headers.TryGetValues(BucketBackupS3Headers.ContentSha256, out var values)
+                && values.Contains(BucketBackupS3Headers.UnsignedPayload, StringComparer.Ordinal);
+            FailureMessage = SawUnsignedPayloadHeader
+                ? null
+                : $"Missing {BucketBackupS3Headers.ContentSha256}";
+
+            return Task.FromResult(new HttpResponseMessage(SawUnsignedPayloadHeader ? System.Net.HttpStatusCode.OK : System.Net.HttpStatusCode.BadRequest)
+            {
+                Content = SawUnsignedPayloadHeader
+                    ? null
+                    : new StringContent("<Error><Code>InvalidRequest</Code><Message>Missing x-amz-content-sha256</Message></Error>")
+            });
+        }
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public TestHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public TestOptionsMonitor(T value)
+        {
+            CurrentValue = value;
+        }
+
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public TestWebHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath);
+        }
+
+        public string ApplicationName { get; set; } = "TelegramPanel.Web.Tests";
+        public string EnvironmentName { get; set; } = "Test";
+        public string WebRootPath { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; }
+    }
+}


### PR DESCRIPTION
## 本次版本主要更新

### 🐛 修复问题

- 修复 Cloudflare R2 存储桶备份上传返回 `Missing x-amz-content-sha256` 的问题。
- R2 预签名 `PUT` 上传会自动携带 `x-amz-content-sha256: UNSIGNED-PAYLOAD`；如果 URL 查询参数已有 `X-Amz-Content-Sha256`，则按签名值发送，不覆盖签名约束。

### 📚 文档更新

- 补充 R2 预签名 `PUT` 上传的 `x-amz-content-sha256` 行为和排障说明。

## 验证

- `dotnet test tests/TelegramPanel.Web.Tests/TelegramPanel.Web.Tests.csproj -c Release --no-build --filter BucketBackupServiceTests`
- `dotnet build TelegramPanel.sln -c Release --no-restore`
- `dotnet test TelegramPanel.sln -c Release --no-build`
- `mkdocs build --strict`

## Issue

- Fixes #83
