### PR TITLE
fix: 修复 Release 执行屏障测试超时

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.51</Version>
-    <AssemblyVersion>1.31.51.0</AssemblyVersion>
-    <FileVersion>1.31.51.0</FileVersion>
-    <InformationalVersion>1.31.51</InformationalVersion>
+    <Version>1.31.52</Version>
+    <AssemblyVersion>1.31.52.0</AssemblyVersion>
+    <FileVersion>1.31.52.0</FileVersion>
+    <InformationalVersion>1.31.52</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/tests/TelegramPanel.Web.Tests/BatchTaskExecutionBarrierTests.cs
+++ b/tests/TelegramPanel.Web.Tests/BatchTaskExecutionBarrierTests.cs
@@ -29,7 +29,7 @@ public sealed class BatchTaskExecutionBarrierTests
         Assert.False(pause.IsCompleted);
 
         harness.Control.CompleteExecution(lease!);
-        await pause.WaitAsync(TimeSpan.FromSeconds(2));
+        await pause.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Equal("paused", harness.Repository.GetStatus(1));
         Assert.False(harness.Control.HasActiveExecution(1));
@@ -64,15 +64,15 @@ public sealed class BatchTaskExecutionBarrierTests
         harness.Repository.AllowPause = allowPause;
 
         var pause = harness.Control.PauseTaskAsync(1);
-        await pauseEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await pauseEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
         var start = harness.Control.TryStartExecutionAsync(1, CancellationToken.None);
         await Task.Delay(50);
         Assert.False(start.IsCompleted);
 
         allowPause.SetResult();
-        await pause.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Null(await start.WaitAsync(TimeSpan.FromSeconds(2)));
+        await pause.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Null(await start.WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Equal("paused", harness.Repository.GetStatus(1));
     }
 
@@ -86,7 +86,7 @@ public sealed class BatchTaskExecutionBarrierTests
         var pause = harness.Control.PauseTaskAsync(1);
         await WaitUntilAsync(() => harness.Repository.GetStatus(1) == "paused");
         harness.Control.CompleteExecution(lease!);
-        await pause.WaitAsync(TimeSpan.FromSeconds(2));
+        await pause.WaitAsync(TimeSpan.FromSeconds(10));
 
         // 模拟旧执行器在取消回调之后又执行一次收尾。
         lease.MarkCompleted();
@@ -120,7 +120,7 @@ public sealed class BatchTaskExecutionBarrierTests
 
         using var context = harness.Control.EnterExecutionContext(lease!);
         var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            harness.Control.PauseTaskAsync(1).WaitAsync(TimeSpan.FromSeconds(2)));
+            harness.Control.PauseTaskAsync(1).WaitAsync(TimeSpan.FromSeconds(10)));
 
         Assert.Contains("不能等待自身退出", error.Message);
         Assert.Equal("paused", harness.Repository.GetStatus(1));
@@ -145,7 +145,7 @@ public sealed class BatchTaskExecutionBarrierTests
         Assert.NotNull(canceled.CompletedAt);
 
         harness.Control.CompleteExecution(lease!);
-        await cancel.WaitAsync(TimeSpan.FromSeconds(2));
+        await cancel.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.False(harness.Control.HasActiveExecution(1));
         Assert.Equal("canceled", harness.Repository.GetStatus(1));
     }
@@ -184,7 +184,7 @@ public sealed class BatchTaskExecutionBarrierTests
         Assert.NotNull(await harness.Repository.GetFreshByIdAsync(1));
 
         harness.Control.CompleteExecution(lease!);
-        await delete.WaitAsync(TimeSpan.FromSeconds(2));
+        await delete.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.Null(await harness.Repository.GetFreshByIdAsync(1));
         Assert.False(harness.Control.HasActiveExecution(1));
     }
@@ -198,7 +198,7 @@ public sealed class BatchTaskExecutionBarrierTests
         Assert.Equal("completed", harness.Repository.GetStatus(1));
     }
 
-    private static TestHarness CreateHarness(string initialStatus = "pending", int stopTimeoutSeconds = 1)
+    private static TestHarness CreateHarness(string initialStatus = "pending", int stopTimeoutSeconds = 10)
     {
         var repository = new InMemoryBatchTaskRepository();
         repository.Seed(new BatchTask
@@ -230,7 +230,7 @@ public sealed class BatchTaskExecutionBarrierTests
 
     private static async Task WaitUntilAsync(Func<bool> condition)
     {
-        var deadline = DateTime.UtcNow.AddSeconds(2);
+        var deadline = DateTime.UtcNow.AddSeconds(10);
         while (!condition())
         {
             if (DateTime.UtcNow >= deadline)


### PR DESCRIPTION
## 本次版本主要更新

### 🐛 修复问题

- 将批量任务执行屏障测试的异步等待窗口从 2 秒放宽到 10 秒，避免 GitHub Actions Linux runner 偶发调度抖动导致 Release 流程失败。
- 将版本号提升到 `1.31.52`，避开已推送但 Release 失败的 `v1.31.51` tag，不移动历史 tag。

## 验证

- `dotnet test tests/TelegramPanel.Web.Tests/TelegramPanel.Web.Tests.csproj -c Release --no-build --filter "BatchTaskExecutionBarrierTests|BucketBackupServiceTests"`
- `dotnet build TelegramPanel.sln -c Release --no-restore`
- `dotnet test TelegramPanel.sln -c Release --no-build`

## 文档

- 未更新文档：本次只调整测试等待窗口与修订版本号，不改变用户可见功能、配置、API 或部署步骤。