### PR TITLE
fix: 修复任务页手机端适配

### DIFF
--- a/frontend/src/components/TaskConfigForm.vue
+++ b/frontend/src/components/TaskConfigForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="task-config-form">
     <el-alert v-if="loading" title="正在加载配置项..." type="info" :closable="false" class="mb-3" />
 
     <template v-if="taskType === 'user_chat_active'">
@@ -1324,6 +1324,10 @@ const AvatarFields = defineComponent({
 .form-hint.no-offset {
   margin-left: 0;
 }
+
+.task-config-form {
+  min-width: 0;
+}
 .message-rule-section {
   margin-bottom: 14px;
 }
@@ -1355,6 +1359,64 @@ const AvatarFields = defineComponent({
 
 .form-hint.compact {
   margin-bottom: 0;
+}
+
+@media (max-width: 640px) {
+  .form-hint {
+    margin-left: 0;
+  }
+
+  .message-rule-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .message-rule-toolbar .el-button {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  :deep(.el-row) {
+    row-gap: 0;
+  }
+
+  :deep(.el-col) {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  :deep(.el-form-item) {
+    display: block;
+  }
+
+  :deep(.el-form-item__label) {
+    justify-content: flex-start;
+    width: 100%;
+    height: auto;
+    margin-bottom: 6px;
+    line-height: 1.4;
+  }
+
+  :deep(.el-form-item__content) {
+    min-width: 0;
+    margin-left: 0 !important;
+  }
+
+  :deep(.el-radio-group) {
+    display: grid;
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+
+  :deep(.el-radio-button),
+  :deep(.el-radio-button__inner) {
+    width: 100%;
+  }
+
+  :deep(.el-radio-button__inner) {
+    white-space: normal;
+    line-height: 1.35;
+  }
 }
 
 .avatar-path {

--- a/frontend/src/views/Tasks.vue
+++ b/frontend/src/views/Tasks.vue
@@ -197,23 +197,23 @@
       </div>
     </el-card>
 
-    <el-dialog v-model="createDialog.visible" title="新建任务" width="760px" destroy-on-close>
+    <el-dialog v-model="createDialog.visible" title="新建任务" width="min(760px, calc(100vw - 24px))" destroy-on-close>
       <el-alert
         title="立即执行会创建一条后台执行记录；Cron 计划会在任务中心的计划任务区域持续调度。"
         type="info"
         :closable="false"
         class="mb-3"
       />
-      <el-form label-width="96px">
+      <el-form :label-position="isTaskDialogCompact ? 'top' : 'right'" :label-width="isTaskDialogCompact ? 'auto' : '96px'">
         <el-row :gutter="12">
-          <el-col :span="12">
+          <el-col :xs="24" :sm="12">
             <el-form-item label="任务分类">
               <el-select v-model="createDialog.form.category" class="full" @change="ensureTaskType">
                 <el-option v-for="category in creatableCategories" :key="category" :label="categoryName(category)" :value="category" />
               </el-select>
             </el-form-item>
           </el-col>
-          <el-col :span="12">
+          <el-col :xs="24" :sm="12">
             <el-form-item label="任务类型">
               <el-select v-model="createDialog.form.taskType" class="full" @change="onTaskTypeChanged">
                 <el-option v-for="item in creatableDefinitions" :key="item.taskType" :label="item.displayName" :value="item.taskType" />
@@ -311,21 +311,21 @@
       </template>
     </el-dialog>
 
-    <el-dialog v-model="detailDialog.visible" :title="detailDialog.title" width="720px">
+    <el-dialog v-model="detailDialog.visible" :title="detailDialog.title" width="min(720px, calc(100vw - 24px))">
       <pre class="detail-pre">{{ detailDialog.content }}</pre>
       <template #footer>
         <el-button type="primary" @click="detailDialog.visible = false">关闭</el-button>
       </template>
     </el-dialog>
 
-    <el-dialog v-model="editTaskDialog.visible" :title="`编辑任务 #${editTaskDialog.id}`" width="760px" destroy-on-close>
+    <el-dialog v-model="editTaskDialog.visible" :title="`编辑任务 #${editTaskDialog.id}`" width="min(760px, calc(100vw - 24px))" destroy-on-close>
       <el-alert
         title="编辑会更新当前任务配置；若任务已完成或失败，可保存后使用重跑创建新任务。"
         type="info"
         :closable="false"
         class="mb-3"
       />
-      <el-form label-width="96px">
+      <el-form :label-position="isTaskDialogCompact ? 'top' : 'right'" :label-width="isTaskDialogCompact ? 'auto' : '96px'">
         <el-form-item label="任务类型">
           <el-input :model-value="taskName(editTaskDialog.form.taskType)" disabled />
         </el-form-item>
@@ -413,6 +413,7 @@ import type { BatchTask, ScheduledTask, TaskDefinition } from '@/api/types'
 import StatusTag from '@/components/StatusTag.vue'
 import TaskConfigForm, { type TaskConfigDraft } from '@/components/TaskConfigForm.vue'
 import { formatTime, taskProgress } from '@/utils/format'
+import { useMediaQuery } from '@/utils/useMediaQuery'
 
 const loading = ref(false)
 const router = useRouter()
@@ -428,6 +429,7 @@ const historyPageSize = ref(50)
 const hasLoaded = ref(false)
 let timer: number | undefined
 let loadPromise: Promise<void> | null = null
+const isTaskDialogCompact = useMediaQuery('(max-width: 640px)')
 
 const needsAutoRefresh = computed(() =>
   tasks.value.some((task) => isActiveStatus(displayStatus(task)))

--- a/frontend/tests/taskCreationVisibility.test.mjs
+++ b/frontend/tests/taskCreationVisibility.test.mjs
@@ -66,3 +66,14 @@ test('账号持续活跃支持回复消息与转发来源配置', () => {
   assert.match(tasksSource, /去重发送: \$\{skipIfLastMessageFromSelf \? '启用/)
 
 })
+
+test('新建任务弹窗在手机端收窄并纵向排版', () => {
+  assert.match(tasksSource, /width="min\(760px, calc\(100vw - 24px\)\)"/)
+  assert.match(tasksSource, /width="min\(720px, calc\(100vw - 24px\)\)"/)
+  assert.match(tasksSource, /:label-position="isTaskDialogCompact \? 'top' : 'right'"/)
+  assert.match(tasksSource, /:label-width="isTaskDialogCompact \? 'auto' : '96px'"/)
+  assert.match(tasksSource, /:xs="24" :sm="12"/)
+  assert.match(taskConfigFormSource, /@media \(max-width: 640px\)/)
+  assert.match(taskConfigFormSource, /grid-template-columns: 1fr;/)
+  assert.match(taskConfigFormSource, /:deep\(\.el-form-item__content\)/)
+})


### PR DESCRIPTION
## 本次变更
- 新建/编辑任务弹窗宽度改为 `min(..., calc(100vw - 24px))`，避免手机端 760px 固定宽度被裁切。
- 手机端任务表单切换为顶部标签，账号持续活跃配置里的列、单选按钮和提示文案纵向排版。
- 增加前端源码测试覆盖响应式合同。

## 验证
- 复现：390px 视口下原弹窗宽度 760px，右侧被裁切。
- 修复后 Playwright：390px 视口弹窗宽 366px，overflowCount=0。
- pnpm --dir frontend test：64 passed
- pnpm --dir frontend run build