### PR TITLE
release: 准备 v1.31.57 开发版

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.56</Version>
-    <AssemblyVersion>1.31.56.0</AssemblyVersion>
-    <FileVersion>1.31.56.0</FileVersion>
-    <InformationalVersion>1.31.56</InformationalVersion>
+    <Version>1.31.57</Version>
+    <AssemblyVersion>1.31.57.0</AssemblyVersion>
+    <FileVersion>1.31.57.0</FileVersion>
+    <InformationalVersion>1.31.57</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 


### PR DESCRIPTION
## 本次变更\n- 将集中版本号从 1.31.56 更新到 1.31.57，使自定义即时任务名称变更部署后可通过 /api/panel/auth/me 明确识别。\n\n## 验证\n- dotnet restore TelegramPanel.sln：通过（刷新 8.* 通配依赖资产）\n- dotnet build TelegramPanel.sln -c Release --no-restore：通过，只有既有 warning\n- dotnet test TelegramPanel.sln -c Release --no-build：447 passed\n