### PR TITLE
fix: 优化 API 权重输入框显示

### DIFF
--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -38,14 +38,14 @@
                     <el-input v-model="profile.apiId" />
                   </el-form-item>
                 </el-col>
-                <el-col :xs="24" :sm="7">
+                <el-col :xs="24" :sm="6">
                   <el-form-item label="ApiHash">
                     <el-input v-model="profile.apiHash" />
                   </el-form-item>
                 </el-col>
-                <el-col :xs="12" :sm="3">
+                <el-col :xs="12" :sm="4">
                   <el-form-item label="权重">
-                    <el-input-number v-model="profile.weight" :min="1" :max="1000" class="full" />
+                    <el-input-number v-model="profile.weight" :min="1" :max="1000" :controls="false" class="full" />
                   </el-form-item>
                 </el-col>
                 <el-col :xs="12" :sm="3">


### PR DESCRIPTION
## 本次修复\n- 移除 Telegram API 权重输入框的浏览器数字加减控件占位。\n- 调整同一行栅格宽度，避免谷歌浏览器窄列中看不到数值。\n\n## 验证\n- pnpm --dir frontend run build\n- pnpm --dir frontend test\n- Chromium smoke：/ui/settings mock API 后确认权重值 7 可见、无 spinner controls、字段宽度 64.7px。\n\n关联 issue：#106