### PR TITLE
fix: 优化账号分类页面布局

### DIFF
--- a/frontend/src/views/AccountCategories.vue
+++ b/frontend/src/views/AccountCategories.vue
@@ -1,108 +1,107 @@
 <template>
   <div class="category-page">
-    <div class="category-grid">
-      <el-card shadow="never" class="page-card">
-        <template #header>
-          <div class="card-header">
-            <span>添加分类</span>
-          </div>
-        </template>
-        <el-form label-position="top">
-          <el-form-item label="分类名称">
-            <el-input v-model="createForm.name" />
-          </el-form-item>
-          <el-form-item label="描述">
-            <el-input v-model="createForm.description" type="textarea" :rows="3" />
-          </el-form-item>
-          <el-form-item>
-            <el-checkbox v-model="createForm.excludeFromOperations">排除操作（不出现在创建/批量任务中）</el-checkbox>
-          </el-form-item>
+    <el-card shadow="never" class="page-card category-create-card">
+      <template #header>
+        <div class="card-header">
+          <span>添加分类</span>
+          <span class="muted">新增后可用于导入、账号筛选和批量任务排除</span>
+        </div>
+      </template>
+      <el-form label-position="top" class="category-create-form">
+        <el-form-item label="分类名称" class="category-name-field">
+          <el-input v-model="createForm.name" placeholder="例如：AI广告" />
+        </el-form-item>
+        <el-form-item label="描述" class="category-description-field">
+          <el-input v-model="createForm.description" type="textarea" :rows="2" placeholder="可选，说明此分类用途" />
+        </el-form-item>
+        <el-form-item label="操作排除" class="category-exclude-field">
+          <el-checkbox v-model="createForm.excludeFromOperations">不出现在创建/批量任务中</el-checkbox>
+        </el-form-item>
+        <el-form-item class="category-submit-field">
           <el-button type="primary" class="full-btn" :disabled="!createForm.name.trim()" :loading="creating" @click="createCategory">
             添加分类
           </el-button>
-        </el-form>
-      </el-card>
+        </el-form-item>
+      </el-form>
+    </el-card>
 
-      <div class="right-column">
-        <el-card shadow="never" class="page-card">
-          <template #header>
-            <div class="card-header">
-              <span>分类列表</span>
-              <el-button :icon="Refresh" :loading="loading" @click="loadAll">刷新</el-button>
-            </div>
+    <el-card shadow="never" class="page-card mt-4">
+      <template #header>
+        <div class="card-header">
+          <span>分类列表</span>
+          <el-button :icon="Refresh" :loading="loading" @click="loadAll">刷新</el-button>
+        </div>
+      </template>
+      <el-table v-loading="loading" :data="categories" stripe>
+        <el-table-column label="分类名称" min-width="150">
+          <template #default="{ row }">
+            <el-tag
+              effect="plain"
+              class="category-name-tag"
+              :style="accountCategoryTagStyle(row)"
+            >
+              {{ row.name }}
+            </el-tag>
           </template>
-          <el-table v-loading="loading" :data="categories" stripe>
-            <el-table-column label="分类名称" min-width="150">
-              <template #default="{ row }">
-                <el-tag
-                  effect="plain"
-                  class="category-name-tag"
-                  :style="accountCategoryTagStyle(row)"
-                >
-                  {{ row.name }}
-                </el-tag>
-              </template>
-            </el-table-column>
-            <el-table-column prop="description" label="描述" min-width="180">
-              <template #default="{ row }">{{ row.description || '-' }}</template>
-            </el-table-column>
-            <el-table-column label="排除操作" width="110">
-              <template #default="{ row }">
-                <el-tag v-if="row.excludeFromOperations" type="warning" size="small">是</el-tag>
-                <span v-else>-</span>
-              </template>
-            </el-table-column>
-            <el-table-column prop="accountCount" label="账号数量" width="100" />
-            <el-table-column label="操作" width="120" fixed="right">
-              <template #default="{ row }">
-                <el-button link type="primary" :icon="Edit" @click="openEdit(row)" />
-                <el-button link type="danger" :icon="Delete" @click="deleteCategory(row)" />
-              </template>
-            </el-table-column>
-          </el-table>
-        </el-card>
-
-        <el-card shadow="never" class="page-card mt-4">
-          <template #header>
-            <div class="card-header">
-              <span>分类绑定账号</span>
-            </div>
+        </el-table-column>
+        <el-table-column prop="description" label="描述" min-width="180">
+          <template #default="{ row }">{{ row.description || '-' }}</template>
+        </el-table-column>
+        <el-table-column label="排除操作" width="110">
+          <template #default="{ row }">
+            <el-tag v-if="row.excludeFromOperations" type="warning" size="small">是</el-tag>
+            <span v-else>-</span>
           </template>
-          <div class="toolbar">
-            <el-select v-model="assignCategoryId" placeholder="-- 请选择分类 --" class="filter" @change="syncSelectedAccounts">
-              <el-option label="-- 请选择分类 --" :value="0" />
-              <el-option v-for="category in categories" :key="category.id" :label="category.name" :value="category.id" />
-            </el-select>
-            <el-button type="primary" :disabled="assignCategoryId === 0 || accountsLoading" :loading="savingAssignments" @click="saveAssignments">
-              保存勾选到分类
-            </el-button>
-            <span class="muted">已选 {{ selectedAccountIds.length }} / {{ accounts.length }}</span>
-          </div>
+        </el-table-column>
+        <el-table-column prop="accountCount" label="账号数量" width="100" />
+        <el-table-column label="操作" width="120" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" :icon="Edit" @click="openEdit(row)" />
+            <el-button link type="danger" :icon="Delete" @click="deleteCategory(row)" />
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
 
-          <el-table
-            ref="accountTableRef"
-            v-loading="accountsLoading"
-            :data="accounts"
-            row-key="id"
-            stripe
-            class="mt-4"
-            @selection-change="onAccountSelectionChange"
-          >
-            <el-table-column type="selection" width="48" reserve-selection />
-            <el-table-column prop="displayPhone" label="手机号" min-width="150" />
-            <el-table-column prop="nickname" label="昵称" min-width="130">
-              <template #default="{ row }">{{ row.nickname || '-' }}</template>
-            </el-table-column>
-            <el-table-column prop="username" label="用户名" min-width="130">
-              <template #default="{ row }">{{ row.username ? `@${row.username}` : '-' }}</template>
-            </el-table-column>
-            <el-table-column label="当前分类" min-width="140">
-              <template #default="{ row }">{{ row.category?.name || '未分类' }}</template>
-            </el-table-column>
-          </el-table>
-        </el-card>
+    <el-card shadow="never" class="page-card mt-4">
+      <template #header>
+        <div class="card-header">
+          <span>分类绑定账号</span>
+        </div>
+      </template>
+      <div class="toolbar category-assignment-toolbar">
+        <el-select v-model="assignCategoryId" placeholder="-- 请选择分类 --" class="filter" @change="syncSelectedAccounts">
+          <el-option label="-- 请选择分类 --" :value="0" />
+          <el-option v-for="category in categories" :key="category.id" :label="category.name" :value="category.id" />
+        </el-select>
+        <el-button type="primary" :disabled="assignCategoryId === 0 || accountsLoading" :loading="savingAssignments" @click="saveAssignments">
+          保存勾选到分类
+        </el-button>
+        <span class="muted">已选 {{ selectedAccountIds.length }} / {{ accounts.length }}</span>
       </div>
-    </div>
+
+      <el-table
+        ref="accountTableRef"
+        v-loading="accountsLoading"
+        :data="accounts"
+        row-key="id"
+        stripe
+        class="mt-4"
+        @selection-change="onAccountSelectionChange"
+      >
+        <el-table-column type="selection" width="48" reserve-selection />
+        <el-table-column prop="displayPhone" label="手机号" min-width="150" />
+        <el-table-column prop="nickname" label="昵称" min-width="130">
+          <template #default="{ row }">{{ row.nickname || '-' }}</template>
+        </el-table-column>
+        <el-table-column prop="username" label="用户名" min-width="130">
+          <template #default="{ row }">{{ row.username ? `@${row.username}` : '-' }}</template>
+        </el-table-column>
+        <el-table-column label="当前分类" min-width="140">
+          <template #default="{ row }">{{ row.category?.name || '未分类' }}</template>
+        </el-table-column>
+      </el-table>
+    </el-card>
 
     <el-dialog v-model="editDialog.visible" title="编辑分类" width="460px">
       <el-form label-position="top">
@@ -296,15 +295,34 @@ onMounted(loadAll)
 </script>
 
 <style scoped>
-.category-grid {
-  display: grid;
-  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  gap: 16px;
-  align-items: start;
+.category-page {
+  width: min(100%, 1536px);
+  margin: 0 auto;
 }
 
-.right-column {
-  min-width: 0;
+.category-page .page-card {
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.category-create-form {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(320px, 1.45fr) minmax(220px, 0.9fr) minmax(120px, auto);
+  gap: 12px;
+  align-items: end;
+}
+
+.category-create-form :deep(.el-form-item) {
+  margin-bottom: 0;
+}
+
+.category-submit-field :deep(.el-form-item__content) {
+  align-items: end;
+}
+
+.category-assignment-toolbar .filter {
+  width: 220px;
 }
 
 .full-btn {
@@ -315,9 +333,20 @@ onMounted(loadAll)
   border-radius: 999px;
 }
 
-@media (max-width: 980px) {
-  .category-grid {
+@media (max-width: 1180px) {
+  .category-create-form {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .category-create-form {
     grid-template-columns: 1fr;
+  }
+
+  .category-assignment-toolbar .filter,
+  .category-assignment-toolbar .el-button {
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## 本次修复\n- 将账号分类页面从左右分裂的窄表单 + 列表布局调整为全宽卡片流。\n- 添加分类表单在宽屏横排，在移动端自动堆叠。\n- 分类列表和分类绑定账号表格统一获得完整内容宽度，避免截图中的中间空洞和左侧窄卡片。\n\n## 验证\n- pnpm --dir frontend run build\n- pnpm --dir frontend test\n- Chromium smoke：mock 分类/账号 API 后验证桌面端 3 个卡片同左对齐、同宽 1536px、纵向堆叠；移动端 390px 视口卡片宽 370px 且创建表单纵向堆叠，无横向溢出。\n\n## 文档\n- 未更新文档：本次仅调整账号分类页面布局，不改变 API、配置、数据结构、任务行为或用户操作流程。