### PR TITLE
修复 README 中的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ More screenshots: `screenshot/`
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.com/#moeacgx/Telegram-Panel&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.dera.page/#moeacgx/Telegram-Panel&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,4 +97,4 @@ dotnet run --project src/TelegramPanel.Web
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.com/#moeacgx/Telegram-Panel&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.dera.page/#moeacgx/Telegram-Panel&Date)


### PR DESCRIPTION
当前 README 里的 Star 历史图表因为数据源接口限制已经无法正常加载，社区已普遍迁移到可用的镜像源。本次变更把图表链接切换到新的镜像源，让统计图恢复正常显示。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Star History chart links in the English and Chinese README files.
  - Replaced outdated chart endpoints with the current Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->