### PR TITLE
fix: 修复代理批量切换与活跃队列轮询

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.63</Version>
-    <AssemblyVersion>1.31.63.0</AssemblyVersion>
-    <FileVersion>1.31.63.0</FileVersion>
-    <InformationalVersion>1.31.63</InformationalVersion>
+    <Version>1.31.64</Version>
+    <AssemblyVersion>1.31.64.0</AssemblyVersion>
+    <FileVersion>1.31.64.0</FileVersion>
+    <InformationalVersion>1.31.64</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/developer/modules.md
+++ b/docs/developer/modules.md
@@ -987,6 +987,8 @@ public IEnumerable<ModuleTaskDefinition> GetTasks(ModuleHostContext context)
 
 自 v1.31.56 起，`user_chat_active` 增加发送动作合同：`message_action_mode=send_generated_text|forward_url`。默认 `send_generated_text` 保持原规则发送，并可通过 `reply_to_message_url` 让文字/图片消息回复目标内的指定消息；前端只填写 Telegram 消息链接并从链接提取消息 ID，原始 API 仍兼容 `reply_to_message_id`，但不再作为界面字段展示。`forward_url` 会忽略 `message_rules`、`dictionary`、图片字典和 AI 验证，改用 `forward_source_urls` 作为来源消息链接列表后调用 Telegram 原生转发；前端不展示内容模式，来源选择按默认随机策略保存，API 自动化如需队列选择仍可显式传 `message_mode=queue`。`forward_mode=with_attribution|hide_attribution` 控制是否保留原作者引用。`skip_if_last_message_from_self=true` 时，执行器会在每次发送或转发前读取目标最新普通消息，若该消息仍由当前执行账号发出，则把本轮记为已处理但不发送，用于避免同账号连续刷屏。前置条件是执行账号能访问来源消息和目标会话；成功判据是任务详情显示发送动作、来源数或回复链接，开启去重时同账号连续发言会跳过本轮，实际发送返回 Telegram 消息 ID。失败排查先看 `recent_failures.reason`，常见原因为回复/来源链接无消息 ID、账号无权访问来源、目标无权发言、回复消息在目标中不存在，或开启去重后无法读取目标最新消息。回滚到 v1.31.55 或更早版本前，应把任务改回 `send_generated_text` 并关闭去重，否则旧版只会按空消息规则处理转发配置且不识别去重字段。
 
+自当前开发版起，转发来源 `forward_source_urls` 与目标字段一样支持单个文本字典变量（例如 `{forward_sources}`），执行器在启动阶段展开全部启用文本项并校验每一项都是 Telegram 消息链接；模块或自动化调用方可以只更新数据字典来影响后续任务来源列表。账号队列模式会持久化 `account_queue_cursor`，有限任务本轮只发送 1 条时，下一次运行会从下一个账号继续，而不是每次固定使用第一个账号。调用方不得自行重置该游标，除非明确想让队列从头开始。
+
 ### 3) 使用 `CreateRoute` 提供自定义创建页
 
 当前主后台是 Vue SPA。外部模块需要自定义表单时，应设置 `ModuleTaskDefinition.CreateRoute`，指向模块自带的静态 Vue 页或宿主 Vue 路由：

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -173,6 +173,8 @@ proxyText: http://user-a:password-a@proxy-a.example.com:8080
 - `POST /api/panel/accounts/batch/proxy`：批量切换账号路由
 - `GET /api/panel/accounts/{id}/proxy/egress`：检测账号实际出口
 
+`POST /api/panel/accounts/batch/proxy` 支持 `strategy=direct|global|existing|warp_per_account|proxy_per_account`。`proxy_per_account` 仅用于批量切换已存在账号代理，必须提供 `proxyText`，每个有效行一个 HTTP 或 SOCKS5 代理，空行和 `#` 注释不计数，数量必须与 `accountIds` 去重后的数量完全一致。服务端会先解析并检测全部代理出口，全部成功后新增或复用代理记录，再按 `accountIds` 顺序逐账号绑定；任一格式、数量、凭据冲突或出口检测失败会返回 `400`，不会修改账号路由。失败排查先看响应 `items[].error` 或全局错误；回滚方式是重新用原代理、全局代理或直连策略批量切换账号。
+
 `POST /api/panel/settings/global-proxy` 使用 `sourceMode=manual|existing`。`existing` 模式
 必须提供 `proxyId`，服务端只保存引用并在运行时解析代理；不会把 WARP 或 Resin 的连接
 凭据复制到全局配置。
@@ -239,6 +241,8 @@ proxyText: http://user-a:password-a@proxy-a.example.com:8080
 完整表达，回滚前应改为全部规则共用一个图片字典或纯文字规则。
 
 自 v1.31.56 起，`user_chat_active.config` 增加 `message_action_mode`、`reply_to_message_url`、`reply_to_message_id`、`forward_source_urls`、`forward_mode` 和 `skip_if_last_message_from_self`。`message_action_mode` 默认为 `send_generated_text`，继续使用 `message_rules` 发送；前端只展示 `reply_to_message_url`，通过 Telegram 消息链接解析回复消息 ID。`reply_to_message_id` 保留为原始 API 兼容字段，自动化调用可继续大于 0 传入，但与 `reply_to_message_url` 同时存在时必须指向同一条消息。`message_action_mode=forward_url` 时，`forward_source_urls` 必须至少包含一个 Telegram 消息链接，`forward_mode=with_attribution|hide_attribution` 控制原生转发是否保留来源引用；此时前端不展示内容模式，默认按随机来源选择保存，原始 API 仍可用 `message_mode=queue` 改为队列选择。此模式不执行模板渲染、图片字典或 AI 验证。`skip_if_last_message_from_self=true` 时，发送或转发前会读取目标最新普通消息；若它仍由当前执行账号发出，本轮记为已处理但不发送，以避免同账号连续刷屏。成功判据是任务详情配置摘要显示“发送动作”和“去重发送”，且转发模式不再显示内容模式；`recent_failures` 为空或只记录真实 Telegram 访问/权限错误。开启去重但无法读取目标最新消息时，本轮会失败并记录原因。回滚到 v1.31.55 或更早版本前，应把任务重新保存为 `send_generated_text` 并关闭去重，否则旧版不会理解转发来源和去重字段。
+
+自当前开发版起，`user_chat_active.config.forward_source_urls` 的单项也可以是单个文本字典变量（例如 `{forward_sources}`）。执行器启动时会把该字典全部启用内容展开为 Telegram 消息链接，字典内容可用换行、空格或逗号分隔多个来源链接；未知、停用、空文本字典或展开后不是有效 Telegram 消息链接都会启动失败，不会静默跳过。`account_mode=queue` 会维护 `account_queue_cursor`，有限任务多次运行时会从上次使用后的下一个账号继续轮询；回滚到旧版前无需迁移，但旧版会忽略该游标并从第一个账号重新开始。
 
 `user_join_subscribe` 会在 `config.failures` 返回最多 200 条失败明细，字段包括 `accountId`、
 `target` 和 `reason`，并会对 Telegram 瞬时连接错误执行一次客户端重建重试。

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -169,9 +169,9 @@ export interface CreateWarpProxyRequest {
   protocol?: WarpProxyProtocol | null
 }
 
-export type AccountProxyStrategy = 'direct' | 'global' | 'existing' | 'warp_per_account' | 'warp_pool'
+export type AccountProxyStrategy = 'direct' | 'global' | 'existing' | 'warp_per_account' | 'warp_pool' | 'proxy_per_account'
 
-export type AccountImportProxyStrategy = AccountProxyStrategy
+export type AccountImportProxyStrategy = Exclude<AccountProxyStrategy, 'proxy_per_account'>
 
 export type ZipImportProxyStrategy = AccountImportProxyStrategy | 'proxy_per_account'
 
@@ -179,6 +179,7 @@ export interface AccountProxyBindingRequest {
   strategy: AccountProxyStrategy
   proxyId?: number | null
   expectedProxyId?: number | null
+  proxyText?: string | null
 }
 
 export interface AccountProxyOperationItem {

--- a/frontend/src/components/TaskConfigForm.vue
+++ b/frontend/src/components/TaskConfigForm.vue
@@ -52,6 +52,7 @@
       <template v-else>
         <el-form-item label="转发来源消息链接">
           <el-input v-model="forms.userChatActive.forwardSourceUrlsText" type="textarea" :rows="4" placeholder="每行一个 Telegram 消息链接，例如 https://t.me/channel/123 或 https://t.me/c/1234567890/123" />
+          <div class="form-hint no-offset">也可单独填写一个文本字典变量，例如 {forward_sources}；字典内容可放多条 Telegram 消息链接。</div>
         </el-form-item>
         <el-form-item label="转发方式">
           <el-radio-group v-model="forms.userChatActive.forwardMode">
@@ -685,6 +686,7 @@ function applyInitialConfig() {
     form.maxMessages = readNumber(cfg.max_messages, 0)
     form.accountMode = normalizeMode(readString(cfg.account_mode, 'random'))
     form.targetMode = normalizeMode(readString(cfg.target_mode, 'queue'))
+    form.accountQueueCursor = Math.max(0, readNumber(cfg.account_queue_cursor, 0))
     form.messageMode = normalizeMode(readString(cfg.message_mode, 'random'))
     form.enableAiVerification = readBoolean(cfg.enable_ai_verification)
     form.aiModel = readString(cfg.ai_model)
@@ -828,6 +830,7 @@ function buildUserChatActiveDraft(): TaskConfigDraft {
   validateUserChatActiveTargetDictionaries(targets)
   if (form.messageActionMode === 'forward_url') {
     if (forwardSourceUrls.length === 0) throw new Error('请至少填写一个转发来源消息链接')
+    validateUserChatActiveForwardSourceDictionaries(forwardSourceUrls)
   } else {
     if (messageRules.length === 0) throw new Error('请至少添加一条消息规则')
     for (const rule of messageRules) {
@@ -882,6 +885,7 @@ function buildUserChatActiveDraft(): TaskConfigDraft {
     delay_min_ms: secondsToMilliseconds(form.delayMinSeconds),
     delay_max_ms: secondsToMilliseconds(form.delayMaxSeconds),
     account_mode: form.accountMode,
+    account_queue_cursor: Math.max(0, form.accountQueueCursor),
     message_mode: effectiveMessageMode,
     target_mode: form.targetMode,
     max_messages: Math.max(0, form.maxMessages),
@@ -1183,6 +1187,7 @@ function defaultUserChatActiveForm() {
     delayMinSeconds: 15,
     delayMaxSeconds: 45,
     maxMessages: 0,
+    accountQueueCursor: 0,
     accountMode: 'random',
     targetMode: 'queue',
     messageMode: 'random',
@@ -1349,6 +1354,16 @@ function validateUserChatActiveTargetDictionaries(targets: string[]) {
     if (!tokenName) continue
     if (tokenName.toLowerCase() === 'time') throw new Error('目标字典不能使用内置时间变量 {time}')
     if (!available.has(tokenName.toLowerCase())) throw new Error(`目标字典无效：{${tokenName}} 不是已启用且有内容的文本字典`)
+  }
+}
+
+function validateUserChatActiveForwardSourceDictionaries(sourceUrls: string[]) {
+  const available = new Set(textDictionaryNames.value.map((x) => x.toLowerCase()))
+  for (const sourceUrl of sourceUrls) {
+    const tokenName = extractSingleDictionaryTokenName(sourceUrl)
+    if (!tokenName) continue
+    if (tokenName.toLowerCase() === 'time') throw new Error('转发来源字典不能使用内置时间变量 {time}')
+    if (!available.has(tokenName.toLowerCase())) throw new Error(`转发来源字典无效：{${tokenName}} 不是已启用且有内容的文本字典`)
   }
 }
 

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -334,6 +334,7 @@
               value="warp_per_account"
               :disabled="!warpAvailable || proxyDialog.accountIds.length > 10"
             >每账号独立 WARP</el-radio-button>
+            <el-radio-button value="proxy_per_account">批量代理一对一</el-radio-button>
           </el-radio-group>
         </el-form-item>
         <el-form-item v-if="proxyDialog.strategy === 'existing'" label="选择代理">
@@ -346,6 +347,16 @@
               :disabled="!proxy.isEnabled"
             />
           </el-select>
+        </el-form-item>
+        <el-form-item v-if="proxyDialog.strategy === 'proxy_per_account'" label="逐账号代理">
+          <el-input
+            v-model="proxyDialog.proxyText"
+            type="textarea"
+            :rows="8"
+            resize="vertical"
+            placeholder="每行一个 HTTP 或 SOCKS5 代理，例如 http://user:pass@host:port 或 socks5://host:port"
+          />
+          <div class="form-hint no-offset">有效代理 {{ proxyDialogProxyCount }} / {{ proxyDialog.accountIds.length }} 条；空行和 # 注释不计数，顺序按当前已选账号顺序逐一绑定。</div>
         </el-form-item>
         <el-alert
           v-if="!proxyDialog.strategy"
@@ -875,7 +886,9 @@ const proxyDialog = reactive({
   strategy: '' as AccountProxyStrategy | '',
   proxyId: null as number | null,
   expectedProxyId: null as number | null,
+  proxyText: '',
 })
+const proxyDialogProxyCount = computed(() => countEffectiveProxyLines(proxyDialog.proxyText))
 let accountProxyOperationToken = 0
 const warpAvailable = computed(() => Boolean(
   warpStatus.value?.platformSupported
@@ -1509,6 +1522,7 @@ function openAccountProxy(accountIds: number[], row?: Row) {
     ? row.proxy ? 'existing' : row.useGlobalProxy ? 'global' : 'direct'
     : ''
   proxyDialog.proxyId = row?.proxy?.id ?? null
+  proxyDialog.proxyText = ''
   proxyDialog.visible = true
 }
 
@@ -1540,6 +1554,22 @@ async function saveAccountProxy() {
     ElMessage.warning('逐账号创建 WARP 单次最多处理 10 个账号')
     return
   }
+  if (strategy === 'proxy_per_account') {
+    const proxyCount = countEffectiveProxyLines(proxyDialog.proxyText)
+    if (proxyCount === 0) {
+      ElMessage.warning('请填写逐账号代理，每行一个代理地址')
+      return
+    }
+    if (proxyCount > 100) {
+      ElMessage.warning('逐账号批量代理单次最多处理 100 条代理')
+      return
+    }
+    if (proxyCount !== accountIds.length) {
+      ElMessage.warning(`账号与代理数量不一致：已选 ${accountIds.length} 个账号，代理文本识别到 ${proxyCount} 条有效代理`)
+      return
+    }
+  }
+
 
   const operationToken = ++accountProxyOperationToken
   proxyDialog.running = true
@@ -1547,8 +1577,9 @@ async function saveAccountProxy() {
     const payload = {
       strategy,
       proxyId: strategy === 'existing' ? proxyId : null,
+      proxyText: strategy === 'proxy_per_account' ? proxyDialog.proxyText : null,
     }
-    if (accountIds.length === 1) {
+    if (accountIds.length === 1 && strategy !== 'proxy_per_account') {
       const result = await panelApi.setAccountProxy(accountIds[0], {
         ...payload,
         expectedProxyId,
@@ -1573,6 +1604,14 @@ async function saveAccountProxy() {
   } finally {
     if (operationToken === accountProxyOperationToken) proxyDialog.running = false
   }
+}
+
+function countEffectiveProxyLines(text: string) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .length
 }
 
 async function checkAccountProxyEgress(row: Row) {

--- a/frontend/tests/accountImportBatchProxy.test.mjs
+++ b/frontend/tests/accountImportBatchProxy.test.mjs
@@ -13,14 +13,10 @@ function sourceSection(startMarker, endMarker) {
   return source.slice(start, end)
 }
 
-test('逐账号批量代理仅扩展 Zip 导入策略', () => {
-  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool'/)
-  assert.match(typesSource, /export type AccountImportProxyStrategy = AccountProxyStrategy/)
+test('逐账号批量代理在导入类型中仅扩展 Zip 导入策略', () => {
+  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool' \| 'proxy_per_account'/)
+  assert.match(typesSource, /export type AccountImportProxyStrategy = Exclude<AccountProxyStrategy, 'proxy_per_account'>/)
   assert.match(typesSource, /export type ZipImportProxyStrategy = AccountImportProxyStrategy \| 'proxy_per_account'/)
-  assert.doesNotMatch(
-    typesSource.match(/export type AccountProxyStrategy = .+/)?.[0] || '',
-    /proxy_per_account/,
-  )
   assert.match(source, /value="proxy_per_account">批量代理一对一/)
   assert.match(source, /批量代理一对一仅适用于 Zip 导入/)
 })

--- a/frontend/tests/accountProxySelection.test.mjs
+++ b/frontend/tests/accountProxySelection.test.mjs
@@ -18,6 +18,15 @@ test('账号代理策略未明确选择时禁止提交', () => {
   assert.match(source, /if \(!strategy\) \{[\s\S]*请先明确选择本次账号切换使用的代理方式/)
 })
 
+test('账号列表批量代理一对一需要代理文本并走批量接口', () => {
+  assert.match(source, /value="proxy_per_account">批量代理一对一/)
+  assert.match(source, /proxyText: ''/)
+  assert.match(source, /function countEffectiveProxyLines\(text: string\)/)
+  assert.match(source, /strategy === 'proxy_per_account' \? proxyDialog\.proxyText : null/)
+  assert.match(source, /accountIds\.length === 1 && strategy !== 'proxy_per_account'/)
+  assert.match(source, /panelApi\.batchSetAccountProxy\(accountIds, payload\)/)
+})
+
 test('账号列表使用代理编号作为主要标识并保留名称提示', () => {
   assert.equal(source.match(/#\{\{ row\.proxy\.id \}\}/g)?.length, 2)
   assert.equal(source.match(/:content="row\.proxy\.name \|\| `代理 #\$\{row\.proxy\.id\}`"/g)?.length, 2)

--- a/frontend/tests/taskCreationVisibility.test.mjs
+++ b/frontend/tests/taskCreationVisibility.test.mjs
@@ -96,6 +96,9 @@ test('账号持续活跃支持回复消息与转发来源配置', () => {
   assert.match(taskConfigFormSource, /v-if="forms\.userChatActive\.messageActionMode === 'send_generated_text'" :span="8"/)
   assert.match(taskConfigFormSource, /message_mode: effectiveMessageMode/)
   assert.match(tasksSource, /\.\.\.\(isForwardMode \? \[\] : \[`内容模式:/)
+  assert.match(taskConfigFormSource, /也可单独填写一个文本字典变量，例如 \{forward_sources\}/)
+  assert.match(taskConfigFormSource, /validateUserChatActiveForwardSourceDictionaries\(forwardSourceUrls\)/)
+  assert.match(taskConfigFormSource, /account_queue_cursor: Math\.max\(0, form\.accountQueueCursor\)/)
 
 })
 

--- a/src/TelegramPanel.Core/Models/AccountImportProxyModels.cs
+++ b/src/TelegramPanel.Core/Models/AccountImportProxyModels.cs
@@ -11,6 +11,18 @@ public sealed class AccountImportProxyBatchException : ArgumentException
 }
 
 /// <summary>
+/// 已完成出口检测并持久化的逐账号代理槽位。重复输入仍保留独立槽位，
+/// 但可以安全复用同一条代理记录。
+/// </summary>
+public sealed record PreparedAccountProxyAssignment(
+    int Slot,
+    int SourceLine,
+    int ProxyId,
+    string ProxyName,
+    string? EgressIp,
+    ProxyConnectionOptions ExpectedConnection);
+
+/// <summary>
 /// 已完成出口检测并持久化的单个代理槽位。重复输入仍保留独立槽位，
 /// 但可以安全复用同一条代理记录。
 /// </summary>

--- a/src/TelegramPanel.Core/Services/Proxy/ProxyManagementService.ImportBatch.cs
+++ b/src/TelegramPanel.Core/Services/Proxy/ProxyManagementService.ImportBatch.cs
@@ -22,6 +22,50 @@ public sealed partial class ProxyManagementService
     {
         if (expectedCount <= 0)
             throw new AccountImportProxyBatchException("压缩包内没有可匹配的账号");
+
+        var assignments = await PrepareAccountProxyAssignmentsCoreAsync(
+            text,
+            expectedCount,
+            $"压缩包识别到 {expectedCount} 个账号",
+            cancellationToken);
+        return assignments
+            .Select(item => new PreparedAccountImportProxy(
+                item.Slot,
+                item.SourceLine,
+                item.ProxyId,
+                item.ProxyName,
+                item.EgressIp,
+                item.ExpectedConnection))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// 为已选择账号准备逐账号代理。全部代理先完成解析和出口检测，
+    /// 只有全部成功后才会一次性新增或复用代理记录。
+    /// </summary>
+    public async Task<IReadOnlyList<PreparedAccountProxyAssignment>>
+        PrepareAccountProxyAssignmentsAsync(
+            string? text,
+            int expectedCount,
+            CancellationToken cancellationToken = default)
+    {
+        if (expectedCount <= 0)
+            throw new AccountImportProxyBatchException("请选择账号");
+
+        return await PrepareAccountProxyAssignmentsCoreAsync(
+            text,
+            expectedCount,
+            $"已选择 {expectedCount} 个账号",
+            cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<PreparedAccountProxyAssignment>>
+        PrepareAccountProxyAssignmentsCoreAsync(
+            string? text,
+            int expectedCount,
+            string expectedCountDescription,
+            CancellationToken cancellationToken)
+    {
         if (expectedCount > MaxPerAccountProxyBatchSize)
         {
             throw new AccountImportProxyBatchException(
@@ -32,7 +76,7 @@ public sealed partial class ProxyManagementService
         if (orderedInputs.Count != expectedCount)
         {
             throw new AccountImportProxyBatchException(
-                $"账号与代理数量不一致：压缩包识别到 {expectedCount} 个账号，代理文本识别到 {orderedInputs.Count} 条有效代理");
+                $"账号与代理数量不一致：{expectedCountDescription}，代理文本识别到 {orderedInputs.Count} 条有效代理");
         }
 
         EnsureNoCredentialConflicts(orderedInputs);
@@ -87,7 +131,7 @@ public sealed partial class ProxyManagementService
             .Select((item, index) =>
             {
                 var proxy = proxyByConnection[item.ConnectionKey];
-                return new PreparedAccountImportProxy(
+                return new PreparedAccountProxyAssignment(
                     index + 1,
                     item.SourceLine,
                     proxy.Id,

--- a/src/TelegramPanel.Web/Api/ProxyApiEndpoints.cs
+++ b/src/TelegramPanel.Web/Api/ProxyApiEndpoints.cs
@@ -497,6 +497,57 @@ public static class ProxyApiEndpoints
     {
         try
         {
+            if (string.Equals(request.Strategy, "proxy_per_account", StringComparison.OrdinalIgnoreCase))
+            {
+                var ids = (request.AccountIds ?? Array.Empty<int>())
+                    .Where(x => x > 0)
+                    .Distinct()
+                    .ToArray();
+                var assignments = await service.PrepareAccountProxyAssignmentsAsync(
+                    request.ProxyText,
+                    ids.Length,
+                    cancellationToken);
+                var items = new List<AccountProxyOperationResult>(ids.Length);
+                for (var index = 0; index < ids.Length; index++)
+                {
+                    var accountId = ids[index];
+                    var assignment = assignments[index];
+                    try
+                    {
+                        var item = (await service.BindAccountsAsync(
+                                new[] { accountId },
+                                new AccountProxyBindingInput(
+                                    "existing",
+                                    assignment.ProxyId,
+                                    ExpectedConnection: assignment.ExpectedConnection),
+                                cancellationToken))
+                            .Items
+                            .Single();
+                        items.Add(item with
+                        {
+                            Summary = item.Success
+                                ? $"已绑定第 {assignment.SourceLine} 行代理 {assignment.ProxyName}"
+                                : item.Summary
+                        });
+                    }
+                    catch (Exception ex) when (IsClientError(ex))
+                    {
+                        items.Add(new AccountProxyOperationResult(
+                            accountId,
+                            null,
+                            false,
+                            "逐账号代理绑定失败",
+                            ex.Message,
+                            assignment.ProxyId));
+                    }
+                }
+
+                return Results.Ok(new AccountProxyBatchResult(
+                    items.Count(x => x.Success),
+                    items.Count(x => !x.Success),
+                    items));
+            }
+
             var result = await service.BindAccountsAsync(
                 request.AccountIds ?? Array.Empty<int>(),
                 new AccountProxyBindingInput(
@@ -680,7 +731,8 @@ public sealed record AccountProxyBindingRequestDto(
 public sealed record BatchAccountProxyBindingRequestDto(
     IReadOnlyList<int>? AccountIds,
     string? Strategy,
-    int? ProxyId);
+    int? ProxyId,
+    string? ProxyText);
 
 public sealed record ProxyCategorySaveRequestDto(
     string? Name,

--- a/src/TelegramPanel.Web/Services/UserChatActiveTaskHandler.cs
+++ b/src/TelegramPanel.Web/Services/UserChatActiveTaskHandler.cs
@@ -23,13 +23,14 @@ internal static class UserChatActiveSendPlanner
         int requestedMessageCount,
         int dictionaryCount,
         string? accountMode,
-        string? messageMode)
+        string? messageMode,
+        int accountQueueCursor = 0)
     {
         if (eligibleAccountCount <= 0 || requestedMessageCount <= 0 || dictionaryCount <= 0)
             return Array.Empty<UserChatActivePlannedSend>();
 
         var effectiveMessageCount = Math.Min(requestedMessageCount, eligibleAccountCount);
-        var accountIndexes = BuildAccountIndexes(eligibleAccountCount, accountMode);
+        var accountIndexes = BuildAccountIndexes(eligibleAccountCount, accountMode, accountQueueCursor);
         var plannedSends = new List<UserChatActivePlannedSend>(effectiveMessageCount);
         var messageQueueIndex = 0;
 
@@ -47,12 +48,33 @@ internal static class UserChatActiveSendPlanner
         return Math.Max(0, completedMessageCount) + Math.Max(0, plannedSendCount);
     }
 
+    public static int NormalizeQueueCursor(int cursor, int count)
+    {
+        if (count <= 1)
+            return 0;
 
-    private static List<int> BuildAccountIndexes(int count, string? mode)
+        var normalized = cursor % count;
+        return normalized < 0 ? normalized + count : normalized;
+    }
+
+    public static int AdvanceQueueCursor(int cursor, int count)
+    {
+        if (count <= 1)
+            return 0;
+
+        return (NormalizeQueueCursor(cursor, count) + 1) % count;
+    }
+
+    private static List<int> BuildAccountIndexes(int count, string? mode, int accountQueueCursor)
     {
         var indexes = Enumerable.Range(0, count).ToList();
         if (string.Equals(mode, UserChatActiveTaskModes.Queue, StringComparison.OrdinalIgnoreCase))
-            return indexes;
+        {
+            var start = NormalizeQueueCursor(accountQueueCursor, count);
+            return start == 0
+                ? indexes
+                : indexes.Skip(start).Concat(indexes.Take(start)).ToList();
+        }
 
         for (var i = indexes.Count - 1; i > 0; i--)
         {
@@ -168,12 +190,19 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
         var verificationFailures = new ConcurrentQueue<VerificationFailure>();
         var verificationTasks = new ConcurrentDictionary<Guid, Task>();
         using var verificationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var accountQueueIndex = 0;
+        var accountQueueIndex = UserChatActiveSendPlanner.NormalizeQueueCursor(
+            config.AccountQueueCursor,
+            accountSlots.Count);
         var messageQueueIndex = 0;
         var targetQueueIndexByAccountId = new Dictionary<int, int>();
         var lastProgressPersistAt = DateTime.UtcNow;
         var useForwardSource = IsForwardSourceMode(config);
-        var contentItemCount = ResolveContentItemCount(config);
+        var expandedForwardSources = useForwardSource
+            ? await ExpandForwardSourceUrlsAsync(config.ForwardSourceUrls, templateRendering, cancellationToken)
+            : ExpandForwardSourceUrlsResult.Ok(new List<string>());
+        if (!expandedForwardSources.Success)
+            throw new InvalidOperationException(expandedForwardSources.Error ?? "转发来源消息链接配置无效");
+        var contentItemCount = useForwardSource ? expandedForwardSources.SourceUrls.Count : ResolveContentItemCount(config);
         var replyToMessageId = useForwardSource ? null : ResolveReplyToMessageId(config);
         var finiteSendPlan = config.MaxMessages > 0
             ? UserChatActiveSendPlanner.BuildFiniteRunPlan(
@@ -181,7 +210,8 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
                 Math.Max(0, config.MaxMessages - progress.Completed),
                 contentItemCount,
                 config.AccountMode,
-                config.MessageMode)
+                config.MessageMode,
+                config.AccountQueueCursor)
             : null;
         if (finiteSendPlan is not null)
         {
@@ -261,6 +291,13 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
                     ? plannedSend.AccountIndex
                     : SelectIndex(config.AccountMode, accountSlots.Count, ref accountQueueIndex);
                 var accountSlot = accountSlots[accountIdx];
+                if (IsQueueMode(config.AccountMode))
+                {
+                    config.AccountQueueCursor = finiteSendPlan is not null
+                        ? UserChatActiveSendPlanner.AdvanceQueueCursor(config.AccountQueueCursor, accountSlots.Count)
+                        : accountQueueIndex;
+                }
+
 
                 if (!targetQueueIndexByAccountId.ContainsKey(accountSlot.Account.Id))
                     targetQueueIndexByAccountId[accountSlot.Account.Id] = 0;
@@ -281,7 +318,7 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
                     break;
                 }
 
-                var forwardSourceUrl = useForwardSource ? config.ForwardSourceUrls[contentIdx] : string.Empty;
+                var forwardSourceUrl = useForwardSource ? expandedForwardSources.SourceUrls[contentIdx] : string.Empty;
                 var messageRule = useForwardSource ? null : config.MessageRules[contentIdx];
                 var textTemplate = messageRule?.Text ?? string.Empty;
                 var text = string.Empty;
@@ -713,6 +750,9 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
 
             foreach (var sourceUrl in config.ForwardSourceUrls)
             {
+                if (IsSingleDictionaryToken(sourceUrl))
+                    continue;
+
                 if (!AccountTelegramToolsService.TryParseTelegramMessageReference(sourceUrl, out _, out var error))
                     throw new InvalidOperationException($"转发消息链接无效：{error ?? sourceUrl}");
             }
@@ -740,6 +780,7 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
         config.AccountMode = NormalizeMode(config.AccountMode);
         config.TargetMode = NormalizeMode(config.TargetMode);
         config.MessageMode = NormalizeMode(config.MessageMode);
+        config.AccountQueueCursor = Math.Max(0, config.AccountQueueCursor);
 
         config.VerificationMatchMode = UserChatActiveAiVerificationMatchModes.Normalize(config.VerificationMatchMode);
         config.VerificationKeywords = NormalizeVerificationItems(config.VerificationKeywords);
@@ -832,10 +873,16 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
             : UserChatActiveTaskModes.Random;
     }
 
+    private static bool IsQueueMode(string? mode) =>
+        string.Equals((mode ?? string.Empty).Trim(), UserChatActiveTaskModes.Queue, StringComparison.OrdinalIgnoreCase);
+
     private static bool IsForwardSourceMode(UserChatActiveTaskConfig config) =>
         string.Equals(config.MessageActionMode, UserChatActiveMessageActionModes.ForwardUrl, StringComparison.Ordinal);
 
     private static bool IsGeneratedMessageMode(UserChatActiveTaskConfig config) => !IsForwardSourceMode(config);
+
+    private static bool IsSingleDictionaryToken(string? value) =>
+        Regex.IsMatch((value ?? string.Empty).Trim(), "^\\{[a-zA-Z0-9_]+\\}$");
 
     private static int ResolveContentItemCount(UserChatActiveTaskConfig config) =>
         IsForwardSourceMode(config) ? config.ForwardSourceUrls.Count : config.MessageRules.Count;
@@ -854,6 +901,55 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
             .Where(x => x.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static async Task<ExpandForwardSourceUrlsResult> ExpandForwardSourceUrlsAsync(
+        IEnumerable<string>? rawSources,
+        TemplateRenderingService templateRendering,
+        CancellationToken cancellationToken)
+    {
+        var sourceUrls = new List<string>();
+        foreach (var raw in rawSources ?? Array.Empty<string>())
+        {
+            var value = (raw ?? string.Empty).Trim();
+            if (value.Length == 0)
+                continue;
+
+            if (IsSingleDictionaryToken(value))
+            {
+                IReadOnlyList<string> dictionaryValues;
+                try
+                {
+                    dictionaryValues = await templateRendering.ResolveTextDictionaryValuesAsync(value, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    return ExpandForwardSourceUrlsResult.Failed($"转发来源字典解析失败：{ex.Message}");
+                }
+
+                sourceUrls.AddRange(dictionaryValues.SelectMany(SplitTargetValues));
+                continue;
+            }
+
+            sourceUrls.AddRange(SplitTargetValues(value));
+        }
+
+        sourceUrls = sourceUrls
+            .Select(x => (x ?? string.Empty).Trim())
+            .Where(x => x.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (sourceUrls.Count == 0)
+            return ExpandForwardSourceUrlsResult.Failed("转发模式缺少消息链接");
+
+        foreach (var sourceUrl in sourceUrls)
+        {
+            if (!AccountTelegramToolsService.TryParseTelegramMessageReference(sourceUrl, out _, out var error))
+                return ExpandForwardSourceUrlsResult.Failed($"转发消息链接无效：{error ?? sourceUrl}");
+        }
+
+        return ExpandForwardSourceUrlsResult.Ok(sourceUrls);
     }
 
     private static int? ResolveReplyToMessageId(UserChatActiveTaskConfig config)
@@ -1324,6 +1420,18 @@ public sealed class UserChatActiveTaskHandler : IModuleTaskHandler
             new(true, null, targets);
 
         public static ExpandTargetsResult Failed(string error) =>
+            new(false, error, new List<string>());
+    }
+
+    private sealed record ExpandForwardSourceUrlsResult(
+        bool Success,
+        string? Error,
+        List<string> SourceUrls)
+    {
+        public static ExpandForwardSourceUrlsResult Ok(List<string> sourceUrls) =>
+            new(true, null, sourceUrls);
+
+        public static ExpandForwardSourceUrlsResult Failed(string error) =>
             new(false, error, new List<string>());
     }
 

--- a/src/TelegramPanel.Web/Services/UserChatActiveTaskModels.cs
+++ b/src/TelegramPanel.Web/Services/UserChatActiveTaskModels.cs
@@ -109,6 +109,9 @@ public sealed class UserChatActiveTaskConfig
     [JsonPropertyName("account_mode")]
     public string AccountMode { get; set; } = UserChatActiveTaskModes.Random;
 
+    [JsonPropertyName("account_queue_cursor")]
+    public int AccountQueueCursor { get; set; }
+
     [JsonPropertyName("message_mode")]
     public string MessageMode { get; set; } = UserChatActiveTaskModes.Random;
 

--- a/tests/TelegramPanel.Web.Tests/BatchProxyAccountImportTests.cs
+++ b/tests/TelegramPanel.Web.Tests/BatchProxyAccountImportTests.cs
@@ -225,6 +225,60 @@ public sealed class BatchProxyAccountImportTests
     }
 
     [Fact]
+    public async Task 账号列表逐账号代理按选择顺序逐一绑定()
+    {
+        await using var fixture = await BatchImportFixture.CreateAsync();
+        var accounts = new[]
+        {
+            new Account
+            {
+                DisplayNumber = 10,
+                Phone = "8613800001501",
+                UserId = 1501,
+                SessionPath = "sessions/8613800001501.session",
+                ApiId = 12345,
+                ApiHash = ApiHash,
+                IsActive = true
+            },
+            new Account
+            {
+                DisplayNumber = 11,
+                Phone = "8613800001502",
+                UserId = 1502,
+                SessionPath = "sessions/8613800001502.session",
+                ApiId = 12345,
+                ApiHash = ApiHash,
+                IsActive = true
+            }
+        };
+        fixture.Db.Accounts.AddRange(accounts);
+        await fixture.Db.SaveChangesAsync();
+
+        var assignments = await fixture.ProxyManagement.PrepareAccountProxyAssignmentsAsync(
+            "http://first.account-proxy.test:8151\n"
+            + "socks5://second.account-proxy.test:8152",
+            accounts.Length);
+
+        for (var index = 0; index < accounts.Length; index++)
+        {
+            var assignment = assignments[index];
+            var result = await fixture.ProxyManagement.BindAccountsAsync(
+                new[] { accounts[index].Id },
+                new AccountProxyBindingInput(
+                    "existing",
+                    assignment.ProxyId,
+                    ExpectedConnection: assignment.ExpectedConnection));
+            Assert.Equal(1, result.Success);
+        }
+
+        var reloaded = await fixture.Db.Accounts.AsNoTracking()
+            .OrderBy(x => x.DisplayNumber)
+            .ToListAsync();
+        Assert.Equal(assignments.Select(x => x.ProxyId), reloaded.Select(x => x.ProxyId!.Value));
+        Assert.Equal(2, fixture.Probe.CallCount);
+    }
+
+    [Fact]
     public async Task 已有启用代理会复用原记录并刷新检测信息()
     {
         await using var fixture = await BatchImportFixture.CreateAsync();

--- a/tests/TelegramPanel.Web.Tests/UserChatActiveSendPlannerTests.cs
+++ b/tests/TelegramPanel.Web.Tests/UserChatActiveSendPlannerTests.cs
@@ -53,6 +53,30 @@ public sealed class UserChatActiveSendPlannerTests
     }
 
     [Fact]
+    public void 队列账号游标会让下一次有限运行接续账号()
+    {
+        var firstRun = UserChatActiveSendPlanner.BuildFiniteRunPlan(
+            eligibleAccountCount: 2,
+            requestedMessageCount: 1,
+            dictionaryCount: 1,
+            accountMode: UserChatActiveTaskModes.Queue,
+            messageMode: UserChatActiveTaskModes.Queue,
+            accountQueueCursor: 0);
+        var nextCursor = UserChatActiveSendPlanner.AdvanceQueueCursor(0, 2);
+
+        var secondRun = UserChatActiveSendPlanner.BuildFiniteRunPlan(
+            eligibleAccountCount: 2,
+            requestedMessageCount: 1,
+            dictionaryCount: 1,
+            accountMode: UserChatActiveTaskModes.Queue,
+            messageMode: UserChatActiveTaskModes.Queue,
+            accountQueueCursor: nextCursor);
+
+        Assert.Equal(0, Assert.Single(firstRun).AccountIndex);
+        Assert.Equal(1, Assert.Single(secondRun).AccountIndex);
+    }
+
+    [Fact]
     public void 消息规则保留多行段落并支持每条独立图片字典()
     {
         var config = new UserChatActiveTaskConfig


### PR DESCRIPTION
## 本次修复

- 修复账号持续活跃任务 `account_mode=queue` 且 `max_messages=1` 时多次运行总是从第一个账号开始的问题，新增并保留 `account_queue_cursor` 运行游标。
- 支持账号持续活跃转发来源 `forward_source_urls` 使用单个文本字典变量，例如 `{forward_sources}`，启动时展开并校验全部来源消息链接。
- 支持账号列表批量切换代理时按已选账号顺序填写逐账号代理文本，服务端先解析/检测全部代理，再逐账号绑定。
- 提升版本到 `v1.31.64`。

## 关联 Issue

- Closes #129
- Closes #130
- Closes #131

## 验证

- `dotnet build TelegramPanel.sln -c Release --no-restore`：通过（保留既有 WindowsBase/MudBlazor/nullable warning）
- `dotnet test tests/TelegramPanel.Web.Tests/TelegramPanel.Web.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~UserChatActiveSendPlannerTests|FullyQualifiedName~BatchProxyAccountImportTests" --logger "console;verbosity=minimal"`：通过，29/29
- `pnpm --dir frontend test`：通过，83/83
- `pnpm --dir frontend run build`：通过（保留既有 Rollup chunk warning）
- `mkdocs build --strict`：通过（保留既有未纳入 nav 的 workflows/2026-07/26_reflection_feature_warp-pool.md 提示）

## 回滚

- 回滚此提交后，逐账号代理批量切换入口消失；已绑定账号可用原有单个/批量代理切换重新绑定。
- 回滚后 `forward_source_urls` 字典变量不会被旧版展开，需改回固定来源链接。
- 回滚后旧版忽略 `account_queue_cursor`，队列有限任务会恢复从第一个账号开始。