### PR TITLE
fix: 修复发布前端测试断言

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.64</Version>
-    <AssemblyVersion>1.31.64.0</AssemblyVersion>
-    <FileVersion>1.31.64.0</FileVersion>
-    <InformationalVersion>1.31.64</InformationalVersion>
+    <Version>1.31.65</Version>
+    <AssemblyVersion>1.31.65.0</AssemblyVersion>
+    <FileVersion>1.31.65.0</FileVersion>
+    <InformationalVersion>1.31.65</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/frontend/tests/accountImportBatchProxy.test.mjs
+++ b/frontend/tests/accountImportBatchProxy.test.mjs
@@ -13,9 +13,10 @@ function sourceSection(startMarker, endMarker) {
   return source.slice(start, end)
 }
 
-test('逐账号批量代理在导入类型中仅扩展 Zip 导入策略', () => {
-  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool' \| 'proxy_per_account'/)
-  assert.match(typesSource, /export type AccountImportProxyStrategy = Exclude<AccountProxyStrategy, 'proxy_per_account'>/)
+test('逐账号批量代理仅扩展 Zip 导入与账号批量绑定策略', () => {
+  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool'/)
+  assert.match(typesSource, /export type AccountProxyBatchStrategy = AccountProxyStrategy \| 'proxy_per_account'/)
+  assert.match(typesSource, /export type AccountImportProxyStrategy = AccountProxyStrategy/)
   assert.match(typesSource, /export type ZipImportProxyStrategy = AccountImportProxyStrategy \| 'proxy_per_account'/)
   assert.match(source, /value="proxy_per_account">批量代理一对一/)
   assert.match(source, /批量代理一对一仅适用于 Zip 导入/)

--- a/frontend/tests/accountProxySelection.test.mjs
+++ b/frontend/tests/accountProxySelection.test.mjs
@@ -6,7 +6,7 @@ const sourceUrl = new URL('../src/views/Accounts.vue', import.meta.url)
 const source = await readFile(sourceUrl, 'utf8')
 
 test('批量切换账号代理时不默认选择直连', () => {
-  assert.match(source, /strategy: '' as AccountProxyStrategy \| ''/)
+  assert.match(source, /strategy: '' as AccountProxyBatchStrategy \| ''/)
   assert.match(
     source,
     /proxyDialog\.strategy = row[\s\S]*\? row\.proxy \? 'existing'[\s\S]*: ''/,


### PR DESCRIPTION
修复 v1.31.64 Release workflow 中 Linux 前端测试失败的问题：类型边界修正后，源码断言测试仍期待旧的 `AccountProxyStrategy | proxy_per_account` 结构。本 PR 将测试期望改为新的 `AccountProxyBatchStrategy` 边界，并把版本提升到 `1.31.65` 作为修正版发布。

验证：
- `pnpm --dir frontend test`：通过，83/83
- `pnpm --dir frontend exec vue-tsc --noEmit`：通过
- `pnpm --dir frontend run build`：通过（保留既有 Rollup chunk warning）
- `dotnet build TelegramPanel.sln -c Release --no-restore`：通过（保留既有 WindowsBase/MudBlazor/nullable warning）