### PR TITLE
release: 发布 v1.31.65 代理批量切换与发布测试修复

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.64</Version>
-    <AssemblyVersion>1.31.64.0</AssemblyVersion>
-    <FileVersion>1.31.64.0</FileVersion>
-    <InformationalVersion>1.31.64</InformationalVersion>
+    <Version>1.31.65</Version>
+    <AssemblyVersion>1.31.65.0</AssemblyVersion>
+    <FileVersion>1.31.65.0</FileVersion>
+    <InformationalVersion>1.31.65</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/frontend/tests/accountImportBatchProxy.test.mjs
+++ b/frontend/tests/accountImportBatchProxy.test.mjs
@@ -13,9 +13,10 @@ function sourceSection(startMarker, endMarker) {
   return source.slice(start, end)
 }
 
-test('逐账号批量代理在导入类型中仅扩展 Zip 导入策略', () => {
-  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool' \| 'proxy_per_account'/)
-  assert.match(typesSource, /export type AccountImportProxyStrategy = Exclude<AccountProxyStrategy, 'proxy_per_account'>/)
+test('逐账号批量代理仅扩展 Zip 导入与账号批量绑定策略', () => {
+  assert.match(typesSource, /export type AccountProxyStrategy = 'direct' \| 'global' \| 'existing' \| 'warp_per_account' \| 'warp_pool'/)
+  assert.match(typesSource, /export type AccountProxyBatchStrategy = AccountProxyStrategy \| 'proxy_per_account'/)
+  assert.match(typesSource, /export type AccountImportProxyStrategy = AccountProxyStrategy/)
   assert.match(typesSource, /export type ZipImportProxyStrategy = AccountImportProxyStrategy \| 'proxy_per_account'/)
   assert.match(source, /value="proxy_per_account">批量代理一对一/)
   assert.match(source, /批量代理一对一仅适用于 Zip 导入/)

--- a/frontend/tests/accountProxySelection.test.mjs
+++ b/frontend/tests/accountProxySelection.test.mjs
@@ -6,7 +6,7 @@ const sourceUrl = new URL('../src/views/Accounts.vue', import.meta.url)
 const source = await readFile(sourceUrl, 'utf8')
 
 test('批量切换账号代理时不默认选择直连', () => {
-  assert.match(source, /strategy: '' as AccountProxyStrategy \| ''/)
+  assert.match(source, /strategy: '' as AccountProxyBatchStrategy \| ''/)
   assert.match(
     source,
     /proxyDialog\.strategy = row[\s\S]*\? row\.proxy \? 'existing'[\s\S]*: ''/,


### PR DESCRIPTION
## 本次版本主要更新

### 修复问题

- 修复账号持续活跃任务在账号队列模式下，`max_messages=1` 多次运行总是使用第一个账号的问题；新增 `account_queue_cursor`，后续运行会接续下一个账号。
- 转发来源消息链接支持文本数据字典变量，例如 `{forward_sources}`；更新字典内容即可影响后续任务来源。
- 账号列表批量切换代理新增“批量代理一对一”：按已选账号顺序每行绑定一个 HTTP/SOCKS5 代理，服务端先全量检测再逐账号绑定。
- 修正前端账号代理策略类型边界，账号登录/导入策略不再混入账号列表批量绑定专用的 `proxy_per_account`。
- 修复 v1.31.64 Release workflow Linux 前端测试断言失败；v1.31.65 作为修正版发布。

## 关联 Issue / PR

- Closes #129
- Closes #130
- Closes #131
- dev PR: #132, #133, #135
- main PR: #134 已合并但 v1.31.64 Release workflow 未产出正式 Release；本 PR 用 v1.31.65 重新发布。

## 验证

- `dotnet build TelegramPanel.sln -c Release --no-restore`：通过（保留既有 WindowsBase/MudBlazor/nullable warning）
- `dotnet test tests/TelegramPanel.Web.Tests/TelegramPanel.Web.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~UserChatActiveSendPlannerTests|FullyQualifiedName~BatchProxyAccountImportTests" --logger "console;verbosity=minimal"`：通过，29/29
- `pnpm --dir frontend test`：通过，83/83
- `pnpm --dir frontend exec vue-tsc --noEmit`：通过
- `pnpm --dir frontend run build`：通过（保留既有 Rollup chunk warning）
- `mkdocs build --strict`：通过（保留既有未纳入 nav 的 workflows/2026-07/26_reflection_feature_warp-pool.md 提示）
- dev Docker Build & Publish：成功，run 32214849834，commit fa85510a868226364c018858f9733dd48a67a07d
- dev 部署：成功，run 32215066091，镜像 `ghcr.io/moeacgx/telegram-panel:dev-latest`

## 回滚

- 回滚此合并后，逐账号代理批量切换入口消失；已绑定账号可用原有单个/批量代理切换重新绑定。
- 回滚后 `forward_source_urls` 字典变量不会被旧版展开，需改回固定来源链接。
- 回滚后旧版忽略 `account_queue_cursor`，队列有限任务会恢复从第一个账号开始。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy strategy handling for batch account operations.
  * Ensured account proxy selection uses the appropriate batch-specific strategy.
  * Preserved consistent proxy behavior for account imports.

* **Chores**
  * Updated the application version to 1.31.65.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->