### PR TITLE
docs: 修复 README Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ More screenshots: `screenshot/`
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.com/#moeacgx/Telegram-Panel&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.dera.page/#moeacgx/Telegram-Panel&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,4 +97,4 @@ dotnet run --project src/TelegramPanel.Web
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.com/#moeacgx/Telegram-Panel&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=moeacgx/Telegram-Panel&type=Date)](https://star-history.dera.page/#moeacgx/Telegram-Panel&Date)


### PR DESCRIPTION
## 本次更新\n- 合入 #128，将 README 和 README.zh-CN 的 Star History 图表切换到可用镜像源。\n\n## 验证\n- PR #128 已合并到 dev：901e5a3915a4f83fab8ab9036d58d53a1bcde1ca。\n- dev Docker Build & Publish：32240636862 success。\n- 本次 main 差异仅 README.md 与 README.zh-CN.md。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English and Simplified Chinese README files.
  * Charts now use the new Star History website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->