### PR TITLE
release: 发布 v1.31.68 Telegram 设置与官方 API 默认值

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.67</Version>
-    <AssemblyVersion>1.31.67.0</AssemblyVersion>
-    <FileVersion>1.31.67.0</FileVersion>
-    <InformationalVersion>1.31.67</InformationalVersion>
+    <Version>1.31.68</Version>
+    <AssemblyVersion>1.31.68.0</AssemblyVersion>
+    <FileVersion>1.31.68.0</FileVersion>
+    <InformationalVersion>1.31.68</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/developer/documentation.md
+++ b/docs/developer/documentation.md
@@ -67,12 +67,13 @@ uv run mkdocs build
 
 适用版本：包含 `Account.DeviceProfileKey` 与迁移 `20260818090000_AddAccountDeviceProfileKey` 的版本。
 
-- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。
+- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 管理默认画像，侧栏 `/telegram-api` 管理默认 API 和 API 配置池。
+- 未配置自定义 `Telegram:ApiId`/`Telegram:ApiHash` 且没有 API 配置池时，`TelegramApiProfilePool` 使用内置 Telegram 官方 Android API（ApiId `6`）作为运行时默认；设置页显示该有效默认值。自定义 API 或 API 池仍优先于内置回退。
 - `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；代理解析与画像解析相互独立，画像不得改变连接出口。
 - 新登录/导入成功入库时保存画像 key；账号详情更新允许清空 key，表示跟随系统默认。更新画像不改写现有 Session，客户端缓存清理后在下一次创建客户端时生效。
-- API 端点：`GET /api/panel/settings` 返回 `telegram.deviceProfiles` 和 `telegram.defaultDeviceProfileKey`；`POST /api/panel/settings/telegram-api` 保存默认 key；账号 `PUT /api/panel/accounts/{id}` 接受 `deviceProfileKey`。
+- API 端点：`GET /api/panel/settings` 返回有效 Telegram API 与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存默认 API、API 池和默认画像；账号 `PUT /api/panel/accounts/{id}` 接受 `deviceProfileKey`。
 
-验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与 86 个前端测试；手工检查系统设置保存、导入页选择、账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key 和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
+验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查侧栏 Telegram 设置、设备指纹页面、官方 API 回退、系统设置和账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
 
 ## GitHub Pages 发布
 

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -58,12 +58,13 @@ Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升
    成功判据：容器正常启动，`/api/panel/auth/me` 可访问，后台能登录，账号列表存在，抽查账号 Session 可读取。若恢复后异常，停止容器，把 `docker-data.before-restore-$ts` 改回 `docker-data` 后再启动，即可回到恢复前状态。
 
 备份 ZIP 包含账号 Session 和后台凭据。下载、解压和临时目录都应只允许管理员访问；恢复完成后按需删除服务器上的 ZIP 和 `/tmp/telegram-panel-restore-*` 临时目录。
-## 设备指纹迁移验收
+## 设备指纹与 Telegram API 验收
 
 包含设备指纹功能的版本会执行 `20260818090000_AddAccountDeviceProfileKey`，只向 `Accounts` 增加可空的 `DeviceProfileKey` 文本列，不改写现有 Session。升级前备份 `docker-data/telegram-panel.db` 和 `docker-data/appsettings.local.json`。
 
-启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；系统设置能看到“默认设备指纹”；账号详情能保存并清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
+启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏出现“Telegram 设置”分组，其中包含“Telegram API”和“设备指纹”；设备指纹页能保存默认画像，Telegram API 页在未配置自定义 API 时显示内置官方 Android ApiId `6`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
 
+官方 API 回退只在默认 API 和 API 配置池都未配置时生效；自建 API、API 配置池和已有账号保存的 ApiId/ApiHash 优先级更高。
 ## 更新策略
 
 Docker 部署支持通过项目根目录 `.env` 的 `TP_UPDATE_MODE` 切换更新方式：

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -56,14 +56,17 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 }
 ```
 
-`profiles` 省略时保留当前配置池；传空数组表示清空配置池。默认 `apiId/apiHash` 可留空，但此时必须至少有一个启用的 profile。服务端会校验每个 ApiHash 为 32 位十六进制字符串，名称不可重复，`weight` 规范到 `1-1000`。新账号登录和不自带 API 的导入入口使用启用 profile 做最少使用量分配；已有账号继续使用数据库中保存的 `ApiId/ApiHash`。
-### Telegram 设备画像
+`profiles` 省略时保留当前 API 配置池；传空数组表示清空配置池。默认 `apiId/apiHash` 可留空，此时没有启用 API 配置池则使用内置 Telegram 官方 Android API（ApiId `6`）；有 API 配置池时按启用项分配。服务端会校验每个 ApiHash 为 32 位十六进制字符串，名称不可重复，`weight` 规范到 `1-1000`。新账号登录和不自带 API 的导入入口使用启用 profile 做最少使用量分配；已有账号继续使用数据库中保存的 `ApiId/ApiHash`。
+### Telegram 设置与设备画像
 
-`GET /api/panel/settings` 在 `telegram.deviceProfiles` 返回启用画像，在 `telegram.defaultDeviceProfileKey` 返回默认 key；`GET /api/panel/settings/device-profiles` 返回同一目录的 `{ items, defaultKey }`。`POST /api/panel/settings/telegram-api` 接收 `defaultDeviceProfileKey` 并持久化到 `Telegram:DefaultDeviceProfileKey`。
+侧栏 `/telegram-api` 对应默认 Telegram API 和 API 配置池；侧栏 `/device-profiles` 对应内置/自定义设备画像和默认画像。两页最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
+
+`GET /api/panel/settings` 返回有效 Telegram API、API 池、启用画像和默认画像 key；`GET /api/panel/settings/device-profiles` 返回同一画像目录的 `{ items, defaultKey }`。
 
 `PUT /api/panel/accounts/{id}` 的请求可携带 `deviceProfileKey`：传画像 key 表示绑定该账号，传空字符串表示清除绑定并跟随系统默认。`GET /api/panel/accounts/{id}` 返回 `deviceProfileKey`。`POST /api/panel/accounts/import/zip`、`POST /api/panel/accounts/import/session-files` 的 multipart 字段名为 `deviceProfileKey`；StringSession JSON 请求同名字段。未知或停用 key 返回 `400`，不会修改账号。
 
 成功判据是保存后重新读取账号详情仍返回该 key，清空后返回 `null`；画像只影响客户端设备字段，不改变 API 凭据、代理策略或 Session 文件格式。数据库列由 `20260818090000_AddAccountDeviceProfileKey` 迁移创建。
+
 `POST /api/panel/settings/username` 的以下合同适用于 v1.31.42 及以上版本。调用方必须
 已经通过管理员 Cookie 认证，请求 JSON 必须提供 `currentPassword` 和 `newUsername`。
 新用户名要求 4-32 位，只包含字母、数字、下划线、短横线或点，且不能使用 `admin`、

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,10 +106,12 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 
 新手机号登录、二维码登录、Session 文件导入、StringSession 导入和纯 TData 导入会在启用配置中按账号已保存的 `ApiId/ApiHash` 使用量选择最少的一项；`Weight` 越大可承载的相对账号数越多。禁用项不会被分配。Telethon Zip 内自带 `api_id/api_hash` 的账号继续使用包内配置。已有账号操作优先使用账号表中保存的 `ApiId/ApiHash`，只有账号缺少这两个字段时才回退全局单 API，因此保存配置池不会迁移或改写已有账号。
 
-如果配置池为空或所有项禁用，系统会继续使用 `Telegram:ApiId` / `Telegram:ApiHash`，保持单 API 部署兼容。保存 Telegram API 设置会清理客户端缓存；正在使用旧 Session 的账号不会被批量改写，如需切换 API 请重新登录或重新导入对应账号。
+如果没有配置 `Telegram:ApiId`/`Telegram:ApiHash`，且没有启用 API 配置池，系统内置 Telegram 官方 Android API 作为默认：ApiId `6`。如需使用自建 API 或其他 API，进入侧栏“Telegram 设置 → Telegram API”配置；已有账号不会被自动改写。
+
+如果配置池为空或所有项禁用，系统会继续使用 `Telegram:ApiId` / `Telegram:ApiHash`，未配置时按上述官方 Android API 回退。保存 Telegram API 设置会清理客户端缓存；正在使用旧 Session 的账号不会被批量改写，如需切换 API 请重新登录或重新导入对应账号。
 ### Telegram 设备指纹画像
 
-适用版本：包含 `20260818090000_AddAccountDeviceProfileKey` 迁移的版本。面板内置四个可选画像：`android-default`、`ios-default`、`macos-default`、`windows-default`；也可在 `Telegram:DeviceProfiles` 中按同样字段覆盖或增加画像。
+适用版本：包含 `20260818090000_AddAccountDeviceProfileKey` 迁移的版本。通过侧栏“Telegram 设置 → 设备指纹”管理默认画像；面板内置四个可选画像：`android-default`、`ios-default`、`macos-default`、`windows-default`；也可在 `Telegram:DeviceProfiles` 中按同样字段覆盖或增加画像。
 
 ```json
 {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -310,6 +310,16 @@ const staticMenuItems: MenuItem[] = [
   { index: '/data-dictionaries', label: '数据字典', icon: 'menu_book' },
   { index: '/modules', label: '模块管理', icon: 'extension' },
   { index: '/apis', label: 'API 管理', icon: 'link' },
+  {
+    index: 'telegram-group',
+    label: 'Telegram 设置',
+    icon: 'tune',
+    children: [
+      { index: '/telegram-api', label: 'Telegram API', icon: 'vpn_key' },
+      { index: '/device-profiles', label: '设备指纹', icon: 'fingerprint' },
+    ],
+  },
+
   { index: '/settings', label: '系统设置', icon: 'settings' },
   { index: 'logout', label: '退出登录', icon: 'logout' },
 ]

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -33,6 +33,9 @@ const routes: RouteRecordRaw[] = [
       { path: 'data-dictionaries', component: () => import('@/views/DataDictionaries.vue'), meta: { title: '数据字典' } },
       { path: 'modules', component: () => import('@/views/Modules.vue'), meta: { title: '模块管理' } },
       { path: 'apis', component: () => import('@/views/ApiCenter.vue'), meta: { title: 'API 管理' } },
+      { path: 'telegram-api', component: () => import('@/views/TelegramApiSettings.vue'), meta: { title: 'Telegram API' } },
+      { path: 'device-profiles', component: () => import('@/views/TelegramDeviceProfiles.vue'), meta: { title: '设备指纹' } },
+
       { path: 'settings', component: () => import('@/views/Settings.vue'), meta: { title: '系统设置' } },
       {
         path: 'ext/:moduleId/:pageKey',

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -1181,7 +1181,7 @@ async function saveDetails() {
       remark: details.form.remark,
       twoFactorPassword: details.form.twoFactorPassword,
       categoryId: details.account.categoryId ?? null,
-      deviceProfileKey: details.form.deviceProfileKey || null,
+      deviceProfileKey: details.form.deviceProfileKey,
     })
     ElMessage.success('账号详情已保存')
     details.visible = false

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -7,84 +7,17 @@
       show-icon
       :title="`写入位置：${settings?.localConfigPath || '-'}`"
     />
+    <el-alert
+      class="mb-4"
+      type="info"
+      :closable="false"
+      show-icon
+      title="Telegram API 配置和设备指纹已拆到侧栏的 Telegram 设置 / 设备指纹 页面。"
+    />
+
 
     <div class="settings-columns">
       <div class="settings-column">
-        <el-card shadow="never" class="page-card">
-          <template #header>Telegram API 配置</template>
-          <el-form label-position="top">
-            <el-form-item label="默认 API ID">
-              <el-input v-model="telegram.apiId" />
-              <div class="muted mt-2">从 https://my.telegram.org 获取。</div>
-            </el-form-item>
-            <el-form-item label="默认 API Hash">
-              <el-input v-model="telegram.apiHash" />
-              <div class="muted mt-2">兼容旧配置；未启用 API 配置池时用于新账号登录和导入。</div>
-            </el-form-item>
-            <el-divider />
-            <div class="section-title">API 配置池</div>
-            <el-alert type="info" :closable="false" show-icon class="mb-3">
-              <template #title>新账号登录、Session 文件、StringSession 和 tdata 导入会在启用的配置间按已保存账号数均衡分配；Zip 内自带 api_id/api_hash 的账号保持包内配置。</template>
-            </el-alert>
-            <div v-for="(profile, index) in telegram.profiles" :key="index" class="api-profile-row">
-              <el-row :gutter="8">
-                <el-col :xs="24" :sm="6">
-                  <el-form-item label="名称">
-                    <el-input v-model="profile.name" placeholder="主 API" />
-                  </el-form-item>
-                </el-col>
-                <el-col :xs="24" :sm="5">
-                  <el-form-item label="ApiId">
-                    <el-input v-model="profile.apiId" />
-                  </el-form-item>
-                </el-col>
-                <el-col :xs="24" :sm="6">
-                  <el-form-item label="ApiHash">
-                    <el-input v-model="profile.apiHash" />
-                  </el-form-item>
-                </el-col>
-                <el-col :xs="12" :sm="4">
-                  <el-form-item label="权重">
-                    <el-input-number v-model="profile.weight" :min="1" :max="1000" :controls="false" class="full" />
-                  </el-form-item>
-                </el-col>
-                <el-col :xs="12" :sm="3">
-                  <el-form-item label="启用">
-                    <el-switch v-model="profile.enabled" />
-                  </el-form-item>
-                </el-col>
-              </el-row>
-              <el-form-item label="备注">
-                <el-input v-model="profile.notes" placeholder="可选" />
-              </el-form-item>
-              <el-button text type="danger" @click="removeApiProfile(index)">删除此配置</el-button>
-            </div>
-            <el-button plain @click="addApiProfile">添加 API 配置</el-button>
-            <el-divider />
-            <div class="section-title">默认设备指纹</div>
-            <el-form-item label="新登录、导入和账号连接默认使用的设备画像">
-              <el-select v-model="telegram.defaultDeviceProfileKey" class="full" filterable>
-                <el-option
-                  v-for="profile in telegram.deviceProfiles || []"
-                  :key="profile.key"
-                  :label="`${profile.name} · ${profile.family}`"
-                  :value="profile.key"
-                />
-              </el-select>
-              <div v-if="selectedDeviceProfile" class="muted mt-2">
-                {{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}
-              </div>
-              <div class="muted mt-2">这是 Telegram 客户端设备画像，不会修改 API ID/Hash；已保存账号仍可单独绑定画像。</div>
-            </el-form-item>
-          </el-form>
-          <el-alert type="info" :closable="false" show-icon class="mb-3">
-            <template #title>Telegram API 状态</template>
-            <div>写入位置：{{ settings?.localConfigPath || '-' }}</div>
-            <div>文件存在：{{ settings?.localConfigExists ? '是' : '否' }}</div>
-            <div>当前生效 ApiId：{{ settings?.system.effectiveApiId || '（未配置）' }}</div>
-          </el-alert>
-          <el-button type="primary" :loading="saving.telegram" @click="saveTelegram">保存配置</el-button>
-        </el-card>
 
         <el-card shadow="never" class="page-card">
           <template #header>
@@ -337,17 +270,10 @@ import { computed, onMounted, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { panelApi } from '@/api/panel'
-import type { SettingsPayload, TelegramApiSettings, TelegramApiProfile, TelegramDeviceProfile } from '@/api/types'
+import type { SettingsPayload } from '@/api/types'
 
 const router = useRouter()
 const settings = ref<SettingsPayload | null>(null)
-const telegram = reactive({
-  apiId: '',
-  apiHash: '',
-  profiles: [] as TelegramApiProfile[],
-  deviceProfiles: [] as TelegramDeviceProfile[],
-  defaultDeviceProfileKey: '',
-})
 const cloudMail = reactive({ baseUrl: '', domain: '', token: '' })
 const cloudToken = reactive({ adminEmail: '', adminPassword: '' })
 const ai = reactive({ endpoint: '', apiKey: '', defaultModel: '', presetModels: [] as string[], retryCount: 2 })
@@ -365,7 +291,6 @@ const presetModelsText = computed({
   },
 })
 const saving = reactive({
-  telegram: false,
   cloudMail: false,
   cloudToken: false,
   ai: false,
@@ -386,28 +311,10 @@ function assign<T extends object>(target: T, source: Partial<T>) {
   Object.assign(target, source)
 }
 
-function normalizeTelegramSettings(source: TelegramApiSettings) {
-  telegram.apiId = source.apiId || ''
-  telegram.apiHash = source.apiHash || ''
-  telegram.deviceProfiles = source.deviceProfiles || []
-  telegram.defaultDeviceProfileKey = source.defaultDeviceProfileKey || telegram.deviceProfiles[0]?.key || ''
-  const profiles = source.profiles || []
-  telegram.profiles = profiles.map((profile) => ({
-    name: profile.name || '',
-    apiId: profile.apiId || '',
-    apiHash: profile.apiHash || '',
-    enabled: profile.enabled !== false,
-    weight: profile.weight || 1,
-    notes: profile.notes || '',
-  }))
-}
-
-const selectedDeviceProfile = computed(() => telegram.deviceProfiles.find((profile) => profile.key === telegram.defaultDeviceProfileKey))
 
 async function load() {
   const data = await panelApi.settings()
   settings.value = data
-  normalizeTelegramSettings(data.telegram)
   assign(cloudMail, data.cloudMail)
   assign(ai, data.ai)
   assign(batch, data.batch)
@@ -431,17 +338,6 @@ async function run(key: keyof typeof saving, action: () => Promise<{ message?: s
   }
 }
 
-function addApiProfile() {
-  telegram.profiles.push({ name: '', apiId: '', apiHash: '', enabled: true, weight: 1, notes: '' })
-}
-
-function removeApiProfile(index: number) {
-  telegram.profiles.splice(index, 1)
-}
-
-function saveTelegram() {
-  return run('telegram', () => panelApi.saveTelegramApiSettings({ ...telegram }))
-}
 
 function saveCloudMail() {
   return run('cloudMail', () => panelApi.saveCloudMailSettings({ ...cloudMail }))

--- a/frontend/src/views/TelegramApiSettings.vue
+++ b/frontend/src/views/TelegramApiSettings.vue
@@ -1,0 +1,223 @@
+<template>
+  <div>
+    <el-alert
+      class="mb-4"
+      type="info"
+      :closable="false"
+      show-icon
+      :title="`写入位置：${settings?.localConfigPath || '-'}`"
+    />
+
+    <div class="settings-columns">
+      <div class="settings-column">
+        <el-card shadow="never" class="page-card">
+          <template #header>Telegram API 配置</template>
+          <el-form label-position="top">
+            <el-form-item label="默认 API ID">
+              <el-input v-model="telegram.apiId" />
+              <div class="muted mt-2">Telegram 官方 API 的默认 ApiId；未启用 API 配置池时，新账号登录和导入将使用这里的 ApiId / ApiHash。</div>
+            </el-form-item>
+            <el-form-item label="默认 API Hash">
+              <el-input v-model="telegram.apiHash" />
+              <div class="muted mt-2">兼容旧配置；留空时会回退到启用的 API 配置池或账号已有的 ApiId / ApiHash。</div>
+            </el-form-item>
+            <el-divider />
+            <div class="section-title">API 配置池</div>
+            <el-alert type="info" :closable="false" show-icon class="mb-3">
+              <template #title>新账号登录、Session 文件、StringSession 和 TData 导入会在启用的配置间按已保存账号数均衡分配；Zip 内自带 api_id/api_hash 的账号保持包内配置。</template>
+            </el-alert>
+            <div v-for="(profile, index) in telegram.profiles" :key="index" class="api-profile-row">
+              <el-row :gutter="8">
+                <el-col :xs="24" :sm="6">
+                  <el-form-item label="名称">
+                    <el-input v-model="profile.name" placeholder="主 API" />
+                  </el-form-item>
+                </el-col>
+                <el-col :xs="24" :sm="5">
+                  <el-form-item label="ApiId">
+                    <el-input v-model="profile.apiId" />
+                  </el-form-item>
+                </el-col>
+                <el-col :xs="24" :sm="6">
+                  <el-form-item label="ApiHash">
+                    <el-input v-model="profile.apiHash" />
+                  </el-form-item>
+                </el-col>
+                <el-col :xs="12" :sm="4">
+                  <el-form-item label="权重">
+                    <el-input-number v-model="profile.weight" :min="1" :max="1000" :controls="false" class="full" />
+                  </el-form-item>
+                </el-col>
+                <el-col :xs="12" :sm="3">
+                  <el-form-item label="启用">
+                    <el-switch v-model="profile.enabled" />
+                  </el-form-item>
+                </el-col>
+              </el-row>
+              <el-form-item label="备注">
+                <el-input v-model="profile.notes" placeholder="可选" />
+              </el-form-item>
+              <el-button text type="danger" @click="removeApiProfile(index)">删除此配置</el-button>
+            </div>
+            <el-button plain @click="addApiProfile">添加 API 配置</el-button>
+          </el-form>
+          <el-alert type="info" :closable="false" show-icon class="mb-3">
+            <template #title>Telegram API 状态</template>
+            <div>写入位置：{{ settings?.localConfigPath || '-' }}</div>
+            <div>文件存在：{{ settings?.localConfigExists ? '是' : '否' }}</div>
+            <div>当前生效 ApiId：{{ settings?.system.effectiveApiId || '（未配置）' }}</div>
+          </el-alert>
+          <el-button type="primary" :loading="saving.telegram" @click="saveTelegram">保存配置</el-button>
+        </el-card>
+      </div>
+
+      <div class="settings-column">
+        <el-card shadow="never" class="page-card">
+          <template #header>官方 API 说明</template>
+          <el-alert type="info" :closable="false" show-icon class="mb-3">
+            <template #title>未配置自定义 API 时，系统默认使用 Telegram 官方 Android API。</template>
+            <div>官方默认：ApiId {{ officialApiId }}；ApiHash 已内置，不需要手工填写。</div>
+            <div>如需其他官方客户端或自建 API，请在上方填写并保存；已有账号仍优先使用账号保存的 ApiId / ApiHash。</div>
+          </el-alert>
+          <el-descriptions :column="1" border size="small">
+            <el-descriptions-item label="官方默认 ApiId">{{ officialApiId }}</el-descriptions-item>
+            <el-descriptions-item label="当前默认 ApiId">{{ telegram.apiId || officialApiId }}</el-descriptions-item>
+            <el-descriptions-item label="启用中的 API 配置">{{ telegram.profiles.filter((profile) => profile.enabled !== false).length }}</el-descriptions-item>
+          </el-descriptions>
+          <div class="button-row mt-3">
+            <el-button plain @click="useOfficialApi">恢复官方默认</el-button>
+          </div>
+        </el-card>
+
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { panelApi } from '@/api/panel'
+import type { SettingsPayload, TelegramApiSettings, TelegramApiProfile } from '@/api/types'
+
+const officialApiId = '6'
+const officialApiHash = 'eb06d4abfb49dc3eeb1aeb98ae0f581e'
+const settings = ref<SettingsPayload | null>(null)
+const telegram = reactive({
+  apiId: '',
+  apiHash: '',
+  profiles: [] as TelegramApiProfile[],
+})
+const saving = reactive({
+  telegram: false,
+})
+
+function normalizeTelegramSettings(source: TelegramApiSettings) {
+  const hasProfiles = (source.profiles?.some((profile) => profile.enabled !== false) || false)
+  telegram.apiId = !source.apiId || source.apiId === '0' ? (hasProfiles ? '' : officialApiId) : source.apiId
+  telegram.apiHash = source.apiHash || (hasProfiles ? '' : officialApiHash)
+  const profiles = source.profiles || []
+  telegram.profiles = profiles.map((profile) => ({
+    name: profile.name || '',
+    apiId: profile.apiId || '',
+    apiHash: profile.apiHash || '',
+    enabled: profile.enabled !== false,
+    weight: profile.weight || 1,
+    notes: profile.notes || '',
+  }))
+}
+
+async function load() {
+  const data = await panelApi.settings()
+  settings.value = data
+  normalizeTelegramSettings(data.telegram)
+}
+
+async function saveTelegram() {
+  saving.telegram = true
+  try {
+    const current = await panelApi.settings()
+    const result = await panelApi.saveTelegramApiSettings({
+      apiId: telegram.apiId,
+      apiHash: telegram.apiHash,
+      profiles: telegram.profiles,
+      deviceProfiles: current.telegram.deviceProfiles || [],
+      defaultDeviceProfileKey: current.telegram.defaultDeviceProfileKey || null,
+    })
+    if (result.message) ElMessage.success(result.message)
+    await load()
+  } finally {
+    saving.telegram = false
+  }
+}
+
+function useOfficialApi() {
+  telegram.apiId = officialApiId
+  telegram.apiHash = officialApiHash
+  ElMessage.info('已恢复官方默认 API；点击保存配置后生效')
+}
+
+function addApiProfile() {
+  telegram.profiles.push({ name: '', apiId: '', apiHash: '', enabled: true, weight: 1, notes: '' })
+}
+
+function removeApiProfile(index: number) {
+  telegram.profiles.splice(index, 1)
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.settings-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.settings-column {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.full {
+  width: 100%;
+}
+
+.mb-4 {
+  margin-bottom: 16px;
+}
+
+.mt-2 {
+  margin-top: 8px;
+}
+
+.mt-3 {
+  margin-top: 12px;
+}
+
+.section-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.api-profile-row {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+@media (max-width: 960px) {
+  .settings-columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/TelegramDeviceProfiles.vue
+++ b/frontend/src/views/TelegramDeviceProfiles.vue
@@ -1,0 +1,181 @@
+<template>
+  <div>
+    <el-alert
+      class="mb-4"
+      type="info"
+      :closable="false"
+      show-icon
+      :title="`写入位置：${settings?.localConfigPath || '-'}`"
+    />
+
+    <div class="settings-columns">
+      <div class="settings-column">
+        <el-card shadow="never" class="page-card">
+          <template #header>设备指纹目录</template>
+          <el-form label-position="top">
+            <el-form-item label="默认设备指纹">
+              <el-select v-model="defaultDeviceProfileKey" class="full" filterable>
+                <el-option
+                  v-for="profile in deviceProfiles"
+                  :key="profile.key"
+                  :label="`${profile.name} · ${profile.family}`"
+                  :value="profile.key"
+                />
+              </el-select>
+              <div v-if="selectedDeviceProfile" class="muted mt-2">
+                {{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}
+              </div>
+              <div class="muted mt-2">这里管理 Telegram 客户端的设备画像目录和新账号/导入/连接使用的默认项；单个账号仍可在账号详情里单独覆盖。</div>
+            </el-form-item>
+          </el-form>
+
+          <el-table v-loading="loading" :data="deviceProfiles" stripe class="mt-3">
+            <el-table-column label="Key" min-width="180" prop="key" />
+            <el-table-column label="名称" min-width="180" prop="name" />
+            <el-table-column label="Family" width="120" prop="family" />
+            <el-table-column label="设备参数" min-width="260">
+              <template #default="{ row }">
+                <div class="cell-main">{{ row.deviceModel }}</div>
+                <div class="cell-sub">{{ row.systemVersion }} · App {{ row.appVersion }}</div>
+              </template>
+            </el-table-column>
+            <el-table-column label="语言" width="160">
+              <template #default="{ row }">
+                <div>{{ row.systemLangCode }}</div>
+                <div class="cell-sub">{{ row.langCode }}</div>
+              </template>
+            </el-table-column>
+            <el-table-column label="来源" width="100">
+              <template #default="{ row }">
+                <el-tag :type="row.builtIn ? 'success' : 'info'" size="small">{{ row.builtIn ? '内置' : '自定义' }}</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="备注" min-width="180">
+              <template #default="{ row }">{{ row.notes || '-' }}</template>
+            </el-table-column>
+          </el-table>
+
+          <div class="button-row mt-3">
+            <el-button type="primary" :loading="saving" @click="saveDefaultDeviceProfile">保存默认画像</el-button>
+          </div>
+        </el-card>
+      </div>
+
+      <div class="settings-column">
+        <el-card shadow="never" class="page-card">
+          <template #header>Telegram API 入口</template>
+          <el-alert type="info" :closable="false" show-icon class="mb-3">
+            <template #title>默认官方 API 和 API 配置池在独立的 Telegram API 页面管理。</template>
+            <div>这里读取当前默认 ApiId、已启用 API 配置池数量和默认设备指纹，便于你确认这两块是否已经生效。</div>
+          </el-alert>
+          <el-descriptions :column="1" border size="small">
+            <el-descriptions-item label="当前默认 ApiId">{{ settings?.telegram.apiId || '（未配置）' }}</el-descriptions-item>
+            <el-descriptions-item label="启用中的 API 配置">{{ enabledApiProfiles.length }}</el-descriptions-item>
+            <el-descriptions-item label="当前默认设备指纹">
+              {{ selectedDeviceProfile ? `${selectedDeviceProfile.name} · ${selectedDeviceProfile.family}` : '（未配置）' }}
+            </el-descriptions-item>
+          </el-descriptions>
+          <div class="button-row mt-3">
+            <el-button type="primary" plain @click="router.push('/telegram-api')">去 Telegram API 页面</el-button>
+          </div>
+        </el-card>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { panelApi } from '@/api/panel'
+import type { SettingsPayload, TelegramApiSettings, TelegramDeviceProfile } from '@/api/types'
+
+const router = useRouter()
+const settings = ref<SettingsPayload | null>(null)
+const loading = ref(false)
+const deviceProfiles = ref<TelegramDeviceProfile[]>([])
+const defaultDeviceProfileKey = ref('')
+const saving = ref(false)
+
+const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === defaultDeviceProfileKey.value))
+const enabledApiProfiles = computed(() => (settings.value?.telegram.profiles || []).filter((profile) => profile.enabled !== false))
+
+function normalizeTelegramSettings(source: TelegramApiSettings) {
+  deviceProfiles.value = source.deviceProfiles || []
+  defaultDeviceProfileKey.value = source.defaultDeviceProfileKey || deviceProfiles.value[0]?.key || ''
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const data = await panelApi.settings()
+    settings.value = data
+    normalizeTelegramSettings(data.telegram)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveDefaultDeviceProfile() {
+  saving.value = true
+  try {
+    const current = await panelApi.settings()
+    const result = await panelApi.saveTelegramApiSettings({
+      apiId: current.telegram.apiId,
+      apiHash: current.telegram.apiHash,
+      profiles: current.telegram.profiles,
+      deviceProfiles: current.telegram.deviceProfiles || [],
+      defaultDeviceProfileKey: defaultDeviceProfileKey.value,
+    })
+    if (result.message) ElMessage.success(result.message)
+    await load()
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.settings-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.settings-column {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.full {
+  width: 100%;
+}
+
+.mb-4 {
+  margin-bottom: 16px;
+}
+
+.mt-2 {
+  margin-top: 8px;
+}
+
+.mt-3 {
+  margin-top: 12px;
+}
+
+@media (max-width: 960px) {
+  .settings-columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/tests/accountDeviceManagement.test.mjs
+++ b/frontend/tests/accountDeviceManagement.test.mjs
@@ -20,6 +20,12 @@ test('踢出设备失败时显示失败结果，成功后立即移除并刷新�
   assert.match(accountsSource, /await refreshDevicesAfterKick\(removedHashes\)/)
 })
 
+test('账号详情清空设备画像时提交空字符串', () => {
+  assert.match(accountsSource, /<el-option label="跟随系统默认" value="" \/>/)
+  assert.match(accountsSource, /deviceProfileKey: details\.form\.deviceProfileKey,/)
+  assert.doesNotMatch(accountsSource, /deviceProfileKey: details\.form\.deviceProfileKey \|\| null/)
+})
+
 test('导出独立 session 注入当前授权的设备画像', () => {
   assert.match(exportSource, /Account_GetAuthorizations\(\)/)
   assert.match(exportSource, /Authorization\.Flags\.current/)

--- a/frontend/tests/mainLayoutMenu.test.mjs
+++ b/frontend/tests/mainLayoutMenu.test.mjs
@@ -9,3 +9,12 @@ test('侧栏子菜单默认全部收起', () => {
   assert.match(source, /const defaultOpeneds: string\[\] = \[\]/)
   assert.equal(source.match(/:default-openeds="defaultOpeneds"/g)?.length, 2)
 })
+
+test('Telegram API 和设备指纹作为独立侧栏页面', async () => {
+  const routerSource = await readFile(new URL('../src/router/index.ts', import.meta.url), 'utf8')
+  assert.match(source, /label: 'Telegram 设置'/)
+  assert.match(source, /label: 'Telegram API'/)
+  assert.match(source, /label: '设备指纹'/)
+  assert.match(routerSource, /path: 'telegram-api'/)
+  assert.match(routerSource, /path: 'device-profiles'/)
+})

--- a/src/TelegramPanel.Core/Services/Telegram/TelegramApiProfilePool.cs
+++ b/src/TelegramPanel.Core/Services/Telegram/TelegramApiProfilePool.cs
@@ -17,6 +17,10 @@ public sealed record TelegramApiProfile(
 
 public sealed class TelegramApiProfilePool
 {
+    public const int OfficialAndroidApiId = 6;
+    public const string OfficialAndroidApiHash = "eb06d4abfb49dc3eeb1aeb98ae0f581e";
+    public const string OfficialAndroidApiName = "Telegram 官方 Android API";
+
     private const int MaxWeight = 1000;
     private readonly IConfiguration _configuration;
 
@@ -144,10 +148,16 @@ public sealed class TelegramApiProfilePool
     public static bool TryGetGlobalFallback(IConfiguration configuration, out TelegramApiCredentials credentials)
     {
         credentials = default!;
-        if (!int.TryParse(configuration["Telegram:ApiId"], out var apiId))
-            return false;
+        var apiIdText = (configuration["Telegram:ApiId"] ?? string.Empty).Trim();
+        var apiHashText = (configuration["Telegram:ApiHash"] ?? string.Empty).Trim();
+        if ((string.IsNullOrWhiteSpace(apiIdText) || apiIdText == "0") && string.IsNullOrWhiteSpace(apiHashText))
+        {
+            credentials = new TelegramApiCredentials(OfficialAndroidApiId, OfficialAndroidApiHash, OfficialAndroidApiName);
+            return true;
+        }
 
-        if (!TryNormalizeCredentials(apiId, configuration["Telegram:ApiHash"], out var apiHash, out _))
+        if (!int.TryParse(apiIdText, out var apiId)
+            || !TryNormalizeCredentials(apiId, apiHashText, out var apiHash, out _))
             return false;
 
         credentials = new TelegramApiCredentials(apiId, apiHash, "默认 API");

--- a/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
+++ b/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
@@ -2389,8 +2389,8 @@ public static class PanelAdminApiEndpoints
             LocalConfigPath: localPath,
             LocalConfigExists: File.Exists(localPath),
             Telegram: new TelegramApiSettingsDto(
-                configuration["Telegram:ApiId"] ?? "",
-                configuration["Telegram:ApiHash"] ?? "",
+                ReadEffectiveTelegramApiId(configuration),
+                ReadEffectiveTelegramApiHash(configuration),
                 ReadTelegramApiProfiles(configuration),
                 TelegramDeviceProfileCatalog.ReadProfiles(configuration).Select(ToDto).ToList(),
                 TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration)),
@@ -2418,7 +2418,7 @@ public static class PanelAdminApiEndpoints
                 configuration.GetValue("TelegramStatus:AutoRefreshDelayMs", 5000)),
             Logging: new LoggingSettingsDto(configuration.GetValue("Serilog:Enabled", false), configuration["Serilog:MinimumLevel:Default"] ?? "Information", configuration.GetValue("Serilog:RetainedFileCountLimit", 30)),
             TimeZone: new TimeZoneSettingsDto(configuration["System:TimeZoneId"] ?? "", $"{tz.Id}（UTC{offset}）"),
-            System: new SystemInfoSettingsDto(VersionService.Version, ".NET 8.0", "SQLite", configuration["Telegram:ApiId"] ?? ""));
+            System: new SystemInfoSettingsDto(VersionService.Version, ".NET 8.0", "SQLite", ReadEffectiveTelegramApiId(configuration)));
 
         return Task.FromResult<IResult>(Results.Ok(dto));
     }
@@ -2545,6 +2545,26 @@ public static class PanelAdminApiEndpoints
                 profile.Weight,
                 profile.Notes))
             .ToList();
+
+    private static string ReadEffectiveTelegramApiId(IConfiguration configuration)
+    {
+        if (TelegramApiProfilePool.GetEnabledProfiles(configuration).Count > 0)
+            return configuration["Telegram:ApiId"] ?? string.Empty;
+
+        return TelegramApiProfilePool.TryGetGlobalFallback(configuration, out var credentials)
+            ? credentials.ApiId.ToString(CultureInfo.InvariantCulture)
+            : configuration["Telegram:ApiId"] ?? string.Empty;
+    }
+
+    private static string ReadEffectiveTelegramApiHash(IConfiguration configuration)
+    {
+        if (TelegramApiProfilePool.ReadConfiguredProfiles(configuration).Count > 0)
+            return configuration["Telegram:ApiHash"] ?? string.Empty;
+
+        return TelegramApiProfilePool.TryGetGlobalFallback(configuration, out var credentials)
+            ? credentials.ApiHash
+            : configuration["Telegram:ApiHash"] ?? string.Empty;
+    }
 
     private static IReadOnlyList<TelegramApiProfile> NormalizeTelegramApiProfiles(
         IReadOnlyList<TelegramApiProfileDto>? profiles,

--- a/tests/TelegramPanel.Web.Tests/BatchProxyAccountImportTests.cs
+++ b/tests/TelegramPanel.Web.Tests/BatchProxyAccountImportTests.cs
@@ -24,7 +24,7 @@ public sealed class BatchProxyAccountImportTests
     private const string ApiHash = "0123456789abcdef0123456789abcdef";
 
     [Fact]
-    public async Task 纯Tdata缺少全局Api时不会检测或保存代理也不会连接Telegram()
+    public async Task 纯Tdata使用内置官方Api时解析失败仍无副作用()
     {
         await using var fixture = await BatchImportFixture.CreateAsync();
         await using var zip = CreateTdataZip();
@@ -36,11 +36,11 @@ public sealed class BatchProxyAccountImportTests
 
         var result = Assert.Single(results);
         Assert.False(result.Success);
-        Assert.Contains("未配置全局 Telegram API", result.Error);
-        Assert.Equal(0, fixture.Probe.CallCount);
+        Assert.Contains("tdata 解析失败", result.Error);
+        Assert.Equal(1, fixture.Probe.CallCount);
         Assert.Equal(0, fixture.Importer.ImportCount);
         Assert.Equal(0, fixture.ClientPool.GetOrCreateCount);
-        Assert.Empty(await fixture.Db.OutboundProxies.AsNoTracking().ToListAsync());
+        Assert.Single(await fixture.Db.OutboundProxies.AsNoTracking().ToListAsync());
     }
 
     [Fact]

--- a/tests/TelegramPanel.Web.Tests/TelegramApiProfilePoolTests.cs
+++ b/tests/TelegramPanel.Web.Tests/TelegramApiProfilePoolTests.cs
@@ -73,6 +73,19 @@ public sealed class TelegramApiProfilePoolTests
     }
 
     [Fact]
+    public void SelectForNewAccount_UsesBuiltInOfficialAndroidApiWhenUnset()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var pool = new TelegramApiProfilePool(configuration);
+
+        var selected = pool.SelectForNewAccount(Array.Empty<Account>());
+
+        Assert.Equal(TelegramApiProfilePool.OfficialAndroidApiId, selected.ApiId);
+        Assert.Equal(TelegramApiProfilePool.OfficialAndroidApiHash, selected.ApiHash);
+        Assert.Equal(TelegramApiProfilePool.OfficialAndroidApiName, selected.ProfileName);
+    }
+
+    [Fact]
     public void NormalizeTelegramApiDefaultInput_TreatsZeroWithoutHashAsProfileOnly()
     {
         var result = PanelAdminApiEndpoints.NormalizeTelegramApiDefaultInput("0", " ");


### PR DESCRIPTION
## 本次更新\n- 新增侧栏 Telegram 设置分组，拆出 Telegram API 和设备指纹独立页面。\n- 设备指纹页管理默认画像；Telegram API 页管理默认 ApiId/ApiHash 与 API 配置池。\n- 未配置自定义 API 且没有启用 API 池时，运行时回退内置 Telegram 官方 Android API（ApiId 6）。\n- 修正账号详情清空设备画像提交空字符串的问题。\n- 同步 API、配置、升级、开发文档与测试。\n\n## 验证\n- frontend tests：88 passed\n- frontend build：通过\n- .NET Web tests：457 passed\n- .NET Release build：通过\n- mkdocs build --strict：通过（保留仓库原有 reflection 页面提示）\n- dev Docker workflow：PR #143 workflow 32288434010 success\n\n## 版本\n- Directory.Build.props：1.31.68\n- dev 合并提交：693600b8846fb8b98ee1c9667638fd89ba85cddc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Telegram API settings and device profile pages.
  * Added sidebar navigation for managing API profiles, credentials, and default device profiles.
  * Added automatic fallback to the official Telegram Android API when no custom API is configured.

* **Bug Fixes**
  * Preserved cleared device-profile values when updating account details.
  * Improved effective API credential handling across settings and system information.

* **Documentation**
  * Updated setup, configuration, API, migration, validation, and troubleshooting guidance.

* **Tests**
  * Added coverage for API fallback, device-profile clearing, and new navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->