### PR TITLE
fix: 明确显示内置官方 API 回退

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.68</Version>
-    <AssemblyVersion>1.31.68.0</AssemblyVersion>
-    <FileVersion>1.31.68.0</FileVersion>
-    <InformationalVersion>1.31.68</InformationalVersion>
+    <Version>1.31.69</Version>
+    <AssemblyVersion>1.31.69.0</AssemblyVersion>
+    <FileVersion>1.31.69.0</FileVersion>
+    <InformationalVersion>1.31.69</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/developer/documentation.md
+++ b/docs/developer/documentation.md
@@ -68,10 +68,10 @@ uv run mkdocs build
 适用版本：包含 `Account.DeviceProfileKey` 与迁移 `20260818090000_AddAccountDeviceProfileKey` 的版本。
 
 - `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 管理默认画像，侧栏 `/telegram-api` 管理默认 API 和 API 配置池。
-- 未配置自定义 `Telegram:ApiId`/`Telegram:ApiHash` 且没有 API 配置池时，`TelegramApiProfilePool` 使用内置 Telegram 官方 Android API（ApiId `6`）作为运行时默认；设置页显示该有效默认值。自定义 API 或 API 池仍优先于内置回退。
+- 未配置自定义 `Telegram:ApiId`/`Telegram:ApiHash` 且没有启用 API 配置池时，`TelegramApiProfilePool` 使用内置 Telegram 官方 Android API（ApiId `6`）作为运行时默认；设置接口必须通过 `telegram.effectiveApiId`、`telegram.effectiveApiSource`、`telegram.officialApiId` 和 `telegram.hasUsableApi` 暴露有效状态，前端不得再只用已写入的 `telegram.apiId/apiHash` 判断可用性。自定义 API 或 API 池仍优先于内置回退。
 - `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；代理解析与画像解析相互独立，画像不得改变连接出口。
 - 新登录/导入成功入库时保存画像 key；账号详情更新允许清空 key，表示跟随系统默认。更新画像不改写现有 Session，客户端缓存清理后在下一次创建客户端时生效。
-- API 端点：`GET /api/panel/settings` 返回有效 Telegram API 与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存默认 API、API 池和默认画像；账号 `PUT /api/panel/accounts/{id}` 接受 `deviceProfileKey`。
+- API 端点：`GET /api/panel/settings` 返回有效 Telegram API、来源字段与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存自定义默认 API、API 池和默认画像，空默认 API 且无启用 profile 必须保留内置官方回退；账号 `PUT /api/panel/accounts/{id}` 接受 `deviceProfileKey`。
 
 验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查侧栏 Telegram 设置、设备指纹页面、官方 API 回退、系统设置和账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
 

--- a/docs/developer/documentation.md
+++ b/docs/developer/documentation.md
@@ -67,13 +67,13 @@ uv run mkdocs build
 
 适用版本：包含 `Account.DeviceProfileKey` 与迁移 `20260818090000_AddAccountDeviceProfileKey` 的版本。
 
-- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 管理默认画像，侧栏 `/telegram-api` 管理默认 API 和 API 配置池。
+- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 是设备画像独立入口，侧栏 `/telegram-api` 是默认 API 和 API 配置池独立入口，不得只藏在系统设置页。
 - 未配置自定义 `Telegram:ApiId`/`Telegram:ApiHash` 且没有启用 API 配置池时，`TelegramApiProfilePool` 使用内置 Telegram 官方 Android API（ApiId `6`）作为运行时默认；设置接口必须通过 `telegram.effectiveApiId`、`telegram.effectiveApiSource`、`telegram.officialApiId` 和 `telegram.hasUsableApi` 暴露有效状态，前端不得再只用已写入的 `telegram.apiId/apiHash` 判断可用性。自定义 API 或 API 池仍优先于内置回退。
-- `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；代理解析与画像解析相互独立，画像不得改变连接出口。
+- `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；手动登录页必须在发送验证码/生成二维码前提交 `deviceProfileKey`，后端需在临时登录状态中冻结该 key，登录成功后保存到账号。代理解析与画像解析相互独立，画像不得改变连接出口。
 - 新登录/导入成功入库时保存画像 key；账号详情更新允许清空 key，表示跟随系统默认。更新画像不改写现有 Session，客户端缓存清理后在下一次创建客户端时生效。
-- API 端点：`GET /api/panel/settings` 返回有效 Telegram API、来源字段与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存自定义默认 API、API 池和默认画像，空默认 API 且无启用 profile 必须保留内置官方回退；账号 `PUT /api/panel/accounts/{id}` 接受 `deviceProfileKey`。
+- API 端点：`GET /api/panel/settings` 返回有效 Telegram API、来源字段与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存自定义默认 API、API 池和默认画像，空默认 API 且无启用 profile 必须保留内置官方回退；账号 `PUT /api/panel/accounts/{id}` 和登录/导入请求接受 `deviceProfileKey`。
 
-验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查侧栏 Telegram 设置、设备指纹页面、官方 API 回退、系统设置和账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
+验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查侧栏独立的 Telegram API 与设备指纹页面、官方 API 回退、手动登录设备指纹选择、系统设置和账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
 
 ## GitHub Pages 发布
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ docker compose up -d
 
 面板内置 Telegram 官方 Android API（ApiId `6`），未填写自定义 `api_id` / `api_hash` 且未启用 API 配置池时可以直接作为运行时默认。
 
-如果需要自建 API、隔离额度或分散新账号，可到 https://my.telegram.org/apps 用任意一个 Telegram 账号申请 `api_id` / `api_hash`，然后在面板「Telegram 设置 → Telegram API」保存。`api_hash` 是 **32 位十六进制字符串（0-9a-f）**，请不要填 Token/用户名/URL 等其它值。
+如果需要自建 API、隔离额度或分散新账号，可到 https://my.telegram.org/apps 用任意一个 Telegram 账号申请 `api_id` / `api_hash`，然后在面板侧栏「Telegram API」保存。`api_hash` 是 **32 位十六进制字符串（0-9a-f）**，请不要填 Token/用户名/URL 等其它值。
 
 ### 导入或登录前先选择账号出口
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -46,12 +46,11 @@ docker compose up -d
 
 登录后到「修改密码」页面改掉即可。
 
-### 必做配置：Telegram API 凭据
+### 可选配置：自定义 Telegram API 凭据
 
-到 https://my.telegram.org/apps 用任意一个 Telegram 账号申请一次 `api_id` / `api_hash`，然后在面板「系统设置」里保存即可。
+面板内置 Telegram 官方 Android API（ApiId `6`），未填写自定义 `api_id` / `api_hash` 且未启用 API 配置池时可以直接作为运行时默认。
 
-> 说明：不需要每个账号都申请，全站共用这一对即可工作。  
-> 注意：`api_hash` 是 **32 位十六进制字符串（0-9a-f）**，请不要填 Token/用户名/URL 等其它值。
+如果需要自建 API、隔离额度或分散新账号，可到 https://my.telegram.org/apps 用任意一个 Telegram 账号申请 `api_id` / `api_hash`，然后在面板「Telegram 设置 → Telegram API」保存。`api_hash` 是 **32 位十六进制字符串（0-9a-f）**，请不要填 Token/用户名/URL 等其它值。
 
 ### 导入或登录前先选择账号出口
 

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -62,9 +62,9 @@ Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升
 
 包含设备指纹功能的版本会执行 `20260818090000_AddAccountDeviceProfileKey`，只向 `Accounts` 增加可空的 `DeviceProfileKey` 文本列，不改写现有 Session。升级前备份 `docker-data/telegram-panel.db` 和 `docker-data/appsettings.local.json`。
 
-启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏出现“Telegram 设置”分组，其中包含“Telegram API”和“设备指纹”；设备指纹页能保存默认画像，Telegram API 页在未配置自定义 API 时显示内置官方 Android ApiId `6`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
+启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏出现“Telegram 设置”分组，其中包含“Telegram API”和“设备指纹”；设备指纹页能保存默认画像；Telegram API 页在未配置自定义 API 时显示“内置官方 Android API：ApiId 6（当前生效）”，`GET /api/panel/settings` 返回 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
 
-官方 API 回退只在默认 API 和 API 配置池都未配置时生效；自建 API、API 配置池和已有账号保存的 ApiId/ApiHash 优先级更高。
+官方 API 回退只在自定义默认 API 和 API 配置池都未配置或均未启用时生效；自建 API、API 配置池和已有账号保存的 ApiId/ApiHash 优先级更高。
 ## 更新策略
 
 Docker 部署支持通过项目根目录 `.env` 的 `TP_UPDATE_MODE` 切换更新方式：

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -62,7 +62,7 @@ Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升
 
 包含设备指纹功能的版本会执行 `20260818090000_AddAccountDeviceProfileKey`，只向 `Accounts` 增加可空的 `DeviceProfileKey` 文本列，不改写现有 Session。升级前备份 `docker-data/telegram-panel.db` 和 `docker-data/appsettings.local.json`。
 
-启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏出现“Telegram 设置”分组，其中包含“Telegram API”和“设备指纹”；设备指纹页能保存默认画像；Telegram API 页在未配置自定义 API 时显示“内置官方 Android API：ApiId 6（当前生效）”，`GET /api/panel/settings` 返回 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
+启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏直接出现“Telegram API”和“设备指纹”两个独立入口；设备指纹页能保存默认画像；手动登录页在发送验证码/生成二维码前可选择“本次登录设备指纹”；Telegram API 页在未配置自定义 API 时显示“内置官方 Android API：ApiId 6（当前生效）”，`GET /api/panel/settings` 返回 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
 
 官方 API 回退只在自定义默认 API 和 API 配置池都未配置或均未启用时生效；自建 API、API 配置池和已有账号保存的 ApiId/ApiHash 优先级更高。
 ## 更新策略

--- a/docs/guides/account-import.md
+++ b/docs/guides/account-import.md
@@ -75,9 +75,9 @@ Socket 可用，且 WARP Compose 覆盖或 `Proxy:Warp:Enabled=true` 已生效�
 前置条件是账号 Session 有效，且面板能读取 `account.getAuthorizations`。成功判据是在账号详情的“在线设备”中，新导出授权的应用、设备型号和系统版本与导出前当前授权一致。失败排查先确认当前设备列表能正常加载，再检查账号代理和 Session；回滚方式是恢复到 v1.31.65，导出将恢复为按 ApiId/Session 稳定选择回退画像，不涉及现有 Session 文件格式迁移。
 ## 导入时选择设备指纹
 
-导入页的“导入后设备指纹”会列出侧栏「Telegram 设置 → 设备指纹」中的启用画像。选择结果会随 Zip、Session 文件和 StringSession 请求提交，并保存到账号的 `DeviceProfileKey`；留空时账号连接使用系统默认画像。手机号登录和二维码登录在首次入库时自动保存当前系统默认画像。
+导入页的“导入后设备指纹”会列出侧栏「设备指纹」中的启用画像。选择结果会随 Zip、Session 文件和 StringSession 请求提交，并保存到账号的 `DeviceProfileKey`；留空时账号连接使用系统默认画像。手机号登录和二维码登录也会在首次连接前提供“本次登录设备指纹”选择，成功入库后保存到账号。
 
-前置条件是已在「Telegram 设置 → 设备指纹」确认可用画像。成功判据是导入结果成功后进入账号详情，仍显示所选画像；清空账号画像并保存后，详情显示“跟随系统默认”。失败排查检查画像 key 是否被停用、数据库迁移是否完成和客户端缓存是否已清理；回滚方式是改回系统默认或恢复到迁移前版本并保留数据库备份。画像变更不会改写现有 Session，下一次创建 Telegram 客户端时生效。
+前置条件是已在侧栏「设备指纹」确认可用画像。成功判据是导入或手动登录结果成功后进入账号详情，仍显示所选画像；清空账号画像并保存后，详情显示“跟随系统默认”。失败排查检查画像 key 是否被停用、数据库迁移是否完成和客户端缓存是否已清理；回滚方式是改回系统默认或恢复到迁移前版本并保留数据库备份。画像变更不会改写现有 Session，下一次创建 Telegram 客户端时生效。
 
 
 ## Zip 逐账号批量代理
@@ -143,7 +143,7 @@ accounts.zip
 
 ## 导入 Session 文件或 StringSession
 
-`.session` 文件支持一次选择多个；StringSession 通过页面文本框导入。这两种方式使用 `GET /api/panel/settings` 返回的有效 Telegram API：未配置自定义 API 且未启用配置池时会回退到内置官方 Android API（ApiId `6`）；如需自建 API 或多 API 分配，可在「Telegram 设置 → Telegram API」配置。导入成功后，账号会保存本次分配到的 `ApiId/ApiHash`，后续不会被全局默认值覆盖。
+`.session` 文件支持一次选择多个；StringSession 通过页面文本框导入。这两种方式使用 `GET /api/panel/settings` 返回的有效 Telegram API：未配置自定义 API 且未启用配置池时会回退到内置官方 Android API（ApiId `6`）；如需自建 API 或多 API 分配，可在侧栏「Telegram API」配置。导入成功后，账号会保存本次分配到的 `ApiId/ApiHash`，后续不会被全局默认值覆盖。
 
 只提供 `.session` 时，系统会尝试从会话读取账号身份；如果 Session 已失效或格式不兼容，
 该条目会导入失败，不会写入一个看似成功但无法连接的账号。

--- a/docs/guides/account-import.md
+++ b/docs/guides/account-import.md
@@ -75,9 +75,9 @@ Socket 可用，且 WARP Compose 覆盖或 `Proxy:Warp:Enabled=true` 已生效�
 前置条件是账号 Session 有效，且面板能读取 `account.getAuthorizations`。成功判据是在账号详情的“在线设备”中，新导出授权的应用、设备型号和系统版本与导出前当前授权一致。失败排查先确认当前设备列表能正常加载，再检查账号代理和 Session；回滚方式是恢复到 v1.31.65，导出将恢复为按 ApiId/Session 稳定选择回退画像，不涉及现有 Session 文件格式迁移。
 ## 导入时选择设备指纹
 
-导入页的“导入后设备指纹”会列出系统设置中的启用画像。选择结果会随 Zip、Session 文件和 StringSession 请求提交，并保存到账号的 `DeviceProfileKey`；留空时账号连接使用系统默认画像。手机号登录和二维码登录在首次入库时自动保存当前系统默认画像。
+导入页的“导入后设备指纹”会列出侧栏「Telegram 设置 → 设备指纹」中的启用画像。选择结果会随 Zip、Session 文件和 StringSession 请求提交，并保存到账号的 `DeviceProfileKey`；留空时账号连接使用系统默认画像。手机号登录和二维码登录在首次入库时自动保存当前系统默认画像。
 
-前置条件是已在“系统设置 → Telegram API 配置 → 默认设备指纹”确认可用画像。成功判据是导入结果成功后进入账号详情，仍显示所选画像；清空账号画像并保存后，详情显示“跟随系统默认”。失败排查检查画像 key 是否被停用、数据库迁移是否完成和客户端缓存是否已清理；回滚方式是改回系统默认或恢复到迁移前版本并保留数据库备份。画像变更不会改写现有 Session，下一次创建 Telegram 客户端时生效。
+前置条件是已在「Telegram 设置 → 设备指纹」确认可用画像。成功判据是导入结果成功后进入账号详情，仍显示所选画像；清空账号画像并保存后，详情显示“跟随系统默认”。失败排查检查画像 key 是否被停用、数据库迁移是否完成和客户端缓存是否已清理；回滚方式是改回系统默认或恢复到迁移前版本并保留数据库备份。画像变更不会改写现有 Session，下一次创建 Telegram 客户端时生效。
 
 
 ## Zip 逐账号批量代理
@@ -143,8 +143,7 @@ accounts.zip
 
 ## 导入 Session 文件或 StringSession
 
-`.session` 文件支持一次选择多个；StringSession 通过页面文本框导入。这两种方式需要先在
-**系统设置** 中配置全局 Telegram `ApiId/ApiHash` 或至少一个启用的 API 配置池项。导入成功后，账号会保存本次分配到的 `ApiId/ApiHash`，后续不会被全局默认值覆盖。
+`.session` 文件支持一次选择多个；StringSession 通过页面文本框导入。这两种方式使用 `GET /api/panel/settings` 返回的有效 Telegram API：未配置自定义 API 且未启用配置池时会回退到内置官方 Android API（ApiId `6`）；如需自建 API 或多 API 分配，可在「Telegram 设置 → Telegram API」配置。导入成功后，账号会保存本次分配到的 `ApiId/ApiHash`，后续不会被全局默认值覆盖。
 
 只提供 `.session` 时，系统会尝试从会话读取账号身份；如果 Session 已失效或格式不兼容，
 该条目会导入失败，不会写入一个看似成功但无法连接的账号。
@@ -179,7 +178,7 @@ tdata-accounts.zip
 
 注意：
 
-- 导入 TData 前，需先在「系统设置」配置全局 Telegram API（`ApiId/ApiHash`）或至少一个启用的 API 配置池项；批量 TData 会按配置池均衡分配
+- 导入 TData 前，系统会使用当前有效 Telegram API；未配置自定义 API 且未启用配置池时回退内置官方 Android API，批量 TData 会按启用的 API 配置池均衡分配
 - 首次导入 TData 时会自动准备解析依赖，耗时会比普通导入长一点
 
 ## 查看导入结果

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -43,7 +43,7 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 
 ### Telegram API 配置池设置
 
-`GET /api/panel/settings` 的 `telegram` 字段包含兼容旧版的 `apiId`、`apiHash`，以及可选 `profiles` 数组。`POST /api/panel/settings/telegram-api` 接收相同结构并写入 `appsettings.local.json`：
+`GET /api/panel/settings` 的 `telegram` 字段包含兼容旧版的已写入自定义 `apiId`、`apiHash`，以及可选 `profiles` 数组；还会返回运行态字段 `effectiveApiId`、`effectiveApiSource`、`effectiveApiName`、`officialApiId`、`officialApiName` 和 `hasUsableApi`，用于前端区分“内置官方 API 回退”和“写入到本地配置的自定义 API”。`POST /api/panel/settings/telegram-api` 接收相同结构并写入 `appsettings.local.json`：
 
 ```json
 {
@@ -56,7 +56,7 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 }
 ```
 
-`profiles` 省略时保留当前 API 配置池；传空数组表示清空配置池。默认 `apiId/apiHash` 可留空，此时没有启用 API 配置池则使用内置 Telegram 官方 Android API（ApiId `6`）；有 API 配置池时按启用项分配。服务端会校验每个 ApiHash 为 32 位十六进制字符串，名称不可重复，`weight` 规范到 `1-1000`。新账号登录和不自带 API 的导入入口使用启用 profile 做最少使用量分配；已有账号继续使用数据库中保存的 `ApiId/ApiHash`。
+`profiles` 省略时保留当前 API 配置池；传空数组表示清空配置池。默认 `apiId/apiHash` 可留空，此时没有启用 API 配置池则使用内置 Telegram 官方 Android API（ApiId `6`，`effectiveApiSource=built_in_official`）；有 API 配置池时按启用项分配。服务端会校验每个 ApiHash 为 32 位十六进制字符串，名称不可重复，`weight` 规范到 `1-1000`。新账号登录和不自带 API 的导入入口使用启用 profile 做最少使用量分配；已有账号继续使用数据库中保存的 `ApiId/ApiHash`。
 ### Telegram 设置与设备画像
 
 侧栏 `/telegram-api` 对应默认 Telegram API 和 API 配置池；侧栏 `/device-profiles` 对应内置/自定义设备画像和默认画像。两页最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -57,13 +57,13 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 ```
 
 `profiles` 省略时保留当前 API 配置池；传空数组表示清空配置池。默认 `apiId/apiHash` 可留空，此时没有启用 API 配置池则使用内置 Telegram 官方 Android API（ApiId `6`，`effectiveApiSource=built_in_official`）；有 API 配置池时按启用项分配。服务端会校验每个 ApiHash 为 32 位十六进制字符串，名称不可重复，`weight` 规范到 `1-1000`。新账号登录和不自带 API 的导入入口使用启用 profile 做最少使用量分配；已有账号继续使用数据库中保存的 `ApiId/ApiHash`。
-### Telegram 设置与设备画像
+### Telegram API 与设备画像
 
-侧栏 `/telegram-api` 对应默认 Telegram API 和 API 配置池；侧栏 `/device-profiles` 对应内置/自定义设备画像和默认画像。两页最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
+侧栏 `/telegram-api` 对应默认 Telegram API 和 API 配置池；侧栏 `/device-profiles` 对应内置/自定义设备画像和默认画像。这两个入口作为独立侧栏菜单展示，不再藏在系统设置页。两页最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
 
 `GET /api/panel/settings` 返回有效 Telegram API、API 池、启用画像和默认画像 key；`GET /api/panel/settings/device-profiles` 返回同一画像目录的 `{ items, defaultKey }`。
 
-`PUT /api/panel/accounts/{id}` 的请求可携带 `deviceProfileKey`：传画像 key 表示绑定该账号，传空字符串表示清除绑定并跟随系统默认。`GET /api/panel/accounts/{id}` 返回 `deviceProfileKey`。`POST /api/panel/accounts/import/zip`、`POST /api/panel/accounts/import/session-files` 的 multipart 字段名为 `deviceProfileKey`；StringSession JSON 请求同名字段。未知或停用 key 返回 `400`，不会修改账号。
+`PUT /api/panel/accounts/{id}` 的请求可携带 `deviceProfileKey`：传画像 key 表示绑定该账号，传空字符串表示清除绑定并跟随系统默认。`GET /api/panel/accounts/{id}` 返回 `deviceProfileKey`。`POST /api/panel/accounts/import/zip`、`POST /api/panel/accounts/import/session-files` 的 multipart 字段名为 `deviceProfileKey`；StringSession JSON 请求同名字段。`POST /api/panel/accounts/login/start` 与 `POST /api/panel/accounts/login/qr/start` 也接受 `deviceProfileKey`，在发送验证码或生成二维码前应用该画像，并在登录成功后保存到账号。未知或停用 key 返回 `400` 或业务失败响应，不会修改账号。
 
 成功判据是保存后重新读取账号详情仍返回该 key，清空后返回 `null`；画像只影响客户端设备字段，不改变 API 凭据、代理策略或 Session 文件格式。数据库列由 `20260818090000_AddAccountDeviceProfileKey` 迁移创建。
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -89,7 +89,7 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 
 ### Telegram API 配置池
 
-`Telegram:ApiId` / `Telegram:ApiHash` 仍是兼容旧版本的默认单 API 配置。需要分散新账号时，可在系统设置的“Telegram API 配置池”添加多个启用项，或手工配置：
+`Telegram:ApiId` / `Telegram:ApiHash` 仍是兼容旧版本的自定义默认单 API 配置。需要分散新账号时，可在侧栏「Telegram 设置 → Telegram API」的“API 配置池”添加多个启用项，或手工配置：
 
 ```json
 {
@@ -106,7 +106,7 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 
 新手机号登录、二维码登录、Session 文件导入、StringSession 导入和纯 TData 导入会在启用配置中按账号已保存的 `ApiId/ApiHash` 使用量选择最少的一项；`Weight` 越大可承载的相对账号数越多。禁用项不会被分配。Telethon Zip 内自带 `api_id/api_hash` 的账号继续使用包内配置。已有账号操作优先使用账号表中保存的 `ApiId/ApiHash`，只有账号缺少这两个字段时才回退全局单 API，因此保存配置池不会迁移或改写已有账号。
 
-如果没有配置 `Telegram:ApiId`/`Telegram:ApiHash`，且没有启用 API 配置池，系统内置 Telegram 官方 Android API 作为默认：ApiId `6`。如需使用自建 API 或其他 API，进入侧栏“Telegram 设置 → Telegram API”配置；已有账号不会被自动改写。
+如果没有配置 `Telegram:ApiId`/`Telegram:ApiHash`，且没有启用 API 配置池，系统内置 Telegram 官方 Android API 作为运行时默认：ApiId `6`。这个内置值不会作为自定义 API 写入 `appsettings.local.json`；`GET /api/panel/settings` 会通过 `telegram.effectiveApiId=6` 与 `telegram.effectiveApiSource=built_in_official` 显示当前生效来源。如需使用自建 API 或其他 API，进入侧栏「Telegram 设置 → Telegram API」配置；已有账号不会被自动改写。
 
 如果配置池为空或所有项禁用，系统会继续使用 `Telegram:ApiId` / `Telegram:ApiHash`，未配置时按上述官方 Android API 回退。保存 Telegram API 设置会清理客户端缓存；正在使用旧 Session 的账号不会被批量改写，如需切换 API 请重新登录或重新导入对应账号。
 ### Telegram 设备指纹画像

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -89,7 +89,7 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 
 ### Telegram API 配置池
 
-`Telegram:ApiId` / `Telegram:ApiHash` 仍是兼容旧版本的自定义默认单 API 配置。需要分散新账号时，可在侧栏「Telegram 设置 → Telegram API」的“API 配置池”添加多个启用项，或手工配置：
+`Telegram:ApiId` / `Telegram:ApiHash` 仍是兼容旧版本的自定义默认单 API 配置。需要分散新账号时，可在侧栏「Telegram API」的“API 配置池”添加多个启用项，或手工配置：
 
 ```json
 {
@@ -106,12 +106,12 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 
 新手机号登录、二维码登录、Session 文件导入、StringSession 导入和纯 TData 导入会在启用配置中按账号已保存的 `ApiId/ApiHash` 使用量选择最少的一项；`Weight` 越大可承载的相对账号数越多。禁用项不会被分配。Telethon Zip 内自带 `api_id/api_hash` 的账号继续使用包内配置。已有账号操作优先使用账号表中保存的 `ApiId/ApiHash`，只有账号缺少这两个字段时才回退全局单 API，因此保存配置池不会迁移或改写已有账号。
 
-如果没有配置 `Telegram:ApiId`/`Telegram:ApiHash`，且没有启用 API 配置池，系统内置 Telegram 官方 Android API 作为运行时默认：ApiId `6`。这个内置值不会作为自定义 API 写入 `appsettings.local.json`；`GET /api/panel/settings` 会通过 `telegram.effectiveApiId=6` 与 `telegram.effectiveApiSource=built_in_official` 显示当前生效来源。如需使用自建 API 或其他 API，进入侧栏「Telegram 设置 → Telegram API」配置；已有账号不会被自动改写。
+如果没有配置 `Telegram:ApiId`/`Telegram:ApiHash`，且没有启用 API 配置池，系统内置 Telegram 官方 Android API 作为运行时默认：ApiId `6`。这个内置值不会作为自定义 API 写入 `appsettings.local.json`；`GET /api/panel/settings` 会通过 `telegram.effectiveApiId=6` 与 `telegram.effectiveApiSource=built_in_official` 显示当前生效来源。如需使用自建 API 或其他 API，进入侧栏「Telegram API」配置；已有账号不会被自动改写。
 
 如果配置池为空或所有项禁用，系统会继续使用 `Telegram:ApiId` / `Telegram:ApiHash`，未配置时按上述官方 Android API 回退。保存 Telegram API 设置会清理客户端缓存；正在使用旧 Session 的账号不会被批量改写，如需切换 API 请重新登录或重新导入对应账号。
 ### Telegram 设备指纹画像
 
-适用版本：包含 `20260818090000_AddAccountDeviceProfileKey` 迁移的版本。通过侧栏“Telegram 设置 → 设备指纹”管理默认画像；面板内置四个可选画像：`android-default`、`ios-default`、`macos-default`、`windows-default`；也可在 `Telegram:DeviceProfiles` 中按同样字段覆盖或增加画像。
+适用版本：包含 `20260818090000_AddAccountDeviceProfileKey` 迁移的版本。通过侧栏「设备指纹」管理默认画像；面板内置四个可选画像：`android-default`、`ios-default`、`macos-default`、`windows-default`；也可在 `Telegram:DeviceProfiles` 中按同样字段覆盖或增加画像。
 
 ```json
 {
@@ -134,9 +134,9 @@ Docker 下常用环境变量（见 `docker-compose.yml`）：
 }
 ```
 
-系统设置页可保存默认画像；账号详情页可为单个账号选择画像，留空表示跟随系统默认。新手机号登录、二维码登录、Session/StringSession/TData 导入会把当时的默认 key 保存到账号；已有账号继续使用其已保存的 key。画像只控制 Telegram 客户端的 `app_version`、`device_model`、`system_version`、语言字段，不改变 API ID/Hash 或代理出口。
+设备指纹页可保存默认画像；手动登录页、导入页和账号详情页可为单次登录/导入或单个账号选择画像，留空表示跟随系统默认。新手机号登录、二维码登录、Session/StringSession/TData 导入会把当时选定的 key 保存到账号；已有账号继续使用其已保存的 key。画像只控制 Telegram 客户端的 `app_version`、`device_model`、`system_version`、语言字段，不改变 API ID/Hash 或代理出口。
 
-成功判据：刷新系统设置仍显示默认画像；账号详情保存后重新打开仍显示所选画像；下一次客户端创建日志/Telegram 授权显示对应设备字段。失败时检查 key 是否启用、`appsettings.local.json` 权限和 `DeviceProfileKey` 数据库列；不要手工删除账号 Session。回滚到不含该迁移的版本前，先把账号画像改回默认并备份数据库；旧版会忽略该列，但需要按项目启动迁移兼容策略执行。
+成功判据：刷新设备指纹页仍显示默认画像；手动登录和导入账号后账号详情显示所选画像；账号详情保存后重新打开仍显示所选画像；下一次客户端创建日志/Telegram 授权显示对应设备字段。失败时检查 key 是否启用、`appsettings.local.json` 权限和 `DeviceProfileKey` 数据库列；不要手工删除账号 Session。回滚到不含该迁移的版本前，先把账号画像改回默认并备份数据库；旧版会忽略该列，但需要按项目启动迁移兼容策略执行。
 
 ### 批量操作间隔与并发
 

--- a/frontend/src/api/panel.ts
+++ b/frontend/src/api/panel.ts
@@ -277,12 +277,14 @@ export const panelApi = {
     loginId?: number
     proxyStrategy: AccountProxyStrategy
     proxyId?: number | null
+    deviceProfileKey?: string | null
   }) =>
     api.post<AccountLoginResponse>('/accounts/login/start', payload, { timeout: 900_000 }).then((r) => r.data),
   startAccountQrLogin: (payload: {
     loginId?: number
     proxyStrategy: AccountProxyStrategy
     proxyId?: number | null
+    deviceProfileKey?: string | null
   }) =>
     api.post<AccountQrLoginResponse>('/accounts/login/qr/start', { ...payload, loginId: payload.loginId || 0 }, { timeout: 900_000 }).then((r) => r.data),
   pollAccountQrLogin: (loginId: number) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -419,6 +419,12 @@ export interface TelegramApiSettings {
   profiles?: TelegramApiProfile[] | null
   deviceProfiles?: TelegramDeviceProfile[] | null
   defaultDeviceProfileKey?: string | null
+  effectiveApiId?: string | null
+  effectiveApiSource?: string | null
+  effectiveApiName?: string | null
+  officialApiId?: string | null
+  officialApiName?: string | null
+  hasUsableApi?: boolean | null
 }
 
 export interface TelegramApiProfile {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -310,15 +310,8 @@ const staticMenuItems: MenuItem[] = [
   { index: '/data-dictionaries', label: '数据字典', icon: 'menu_book' },
   { index: '/modules', label: '模块管理', icon: 'extension' },
   { index: '/apis', label: 'API 管理', icon: 'link' },
-  {
-    index: 'telegram-group',
-    label: 'Telegram 设置',
-    icon: 'tune',
-    children: [
-      { index: '/telegram-api', label: 'Telegram API', icon: 'vpn_key' },
-      { index: '/device-profiles', label: '设备指纹', icon: 'fingerprint' },
-    ],
-  },
+  { index: '/telegram-api', label: 'Telegram API', icon: 'vpn_key' },
+  { index: '/device-profiles', label: '设备指纹', icon: 'fingerprint' },
 
   { index: '/settings', label: '系统设置', icon: 'settings' },
   { index: 'logout', label: '退出登录', icon: 'logout' },

--- a/frontend/src/views/AccountImport.vue
+++ b/frontend/src/views/AccountImport.vue
@@ -7,10 +7,10 @@
       show-icon
       class="mb-3"
     >
-      <template #title>未配置全局 Telegram API（ApiId/ApiHash），Session 文件和 StringSession 暂不能导入。</template>
+      <template #title>Telegram API 当前不可用，Session 文件和 StringSession 暂不能导入。</template>
       <div class="import-api-warning">
         <span>当前生效 ApiId：{{ effectiveApiId || '未配置' }}</span>
-        <el-button size="small" type="primary" @click="router.push('/settings')">去系统设置配置</el-button>
+        <el-button size="small" type="primary" @click="router.push('/telegram-api')">去 Telegram API 配置</el-button>
       </div>
     </el-alert>
 
@@ -746,9 +746,11 @@ async function loadTelegramApiStatus() {
       return profile.enabled && !!profileApiId && !!profileApiHash
     })
     const profileApiId = (enabledProfile?.apiId || '').trim()
-    const effectiveApiIdFromSettings = (settings.system.effectiveApiId || '').trim()
+    const effectiveApiIdFromSettings = (settings.telegram.effectiveApiId || settings.system.effectiveApiId || '').trim()
     effectiveApiId.value = ((effectiveApiIdFromSettings !== '0' ? effectiveApiIdFromSettings : '') || (apiId !== '0' ? apiId : '') || profileApiId || '').trim()
-    telegramApiConfigured.value = (!!apiId && apiId !== '0' && !!apiHash) || !!enabledProfile
+    telegramApiConfigured.value = typeof settings.telegram.hasUsableApi === 'boolean'
+      ? settings.telegram.hasUsableApi
+      : ((!!apiId && apiId !== '0' && !!apiHash) || !!enabledProfile)
   } catch {
     telegramApiConfigured.value = true
   } finally {

--- a/frontend/src/views/AccountLogin.vue
+++ b/frontend/src/views/AccountLogin.vue
@@ -60,6 +60,28 @@
         </div>
       </section>
 
+      <section class="login-device-profile" aria-label="手动登录设备指纹">
+        <div class="login-proxy-heading">
+          <span class="material-icons">fingerprint</span>
+          <div>
+            <div class="cell-main">本次登录设备指纹</div>
+            <div class="cell-sub">发送验证码或生成二维码前生效；成功后保存到账号，类似 TokensPro 的设备画像选择</div>
+          </div>
+        </div>
+        <el-select v-model="deviceProfileKey" class="login-device-select" filterable :disabled="proxyRouteLocked">
+          <el-option
+            v-for="profile in deviceProfiles"
+            :key="profile.key"
+            :value="profile.key"
+            :label="`${profile.name} · ${profile.family}`"
+          />
+        </el-select>
+        <div v-if="selectedDeviceProfile" class="login-device-summary">
+          <span class="material-icons">devices</span>
+          <span>{{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}</span>
+        </div>
+      </section>
+
       <template v-if="loginMode === 'qr'">
         <div class="qr-body">
           <el-alert
@@ -327,8 +349,8 @@ import type {
   AccountProxyStrategy,
   AccountQrLoginResponse,
   OutboundProxy,
+  TelegramDeviceProfile,
 } from '@/api/types'
-
 type LoginStep = 'phone' | 'code' | 'password' | 'done'
 type LoginMode = 'qr' | 'phone'
 
@@ -363,6 +385,8 @@ const saveQrPasswordToSystem = ref(false)
 const proxies = ref<OutboundProxy[]>([])
 const proxyStrategy = ref<AccountProxyStrategy | ''>('')
 const proxyId = ref<number | null>(null)
+const deviceProfiles = ref<TelegramDeviceProfile[]>([])
+const deviceProfileKey = ref('')
 let qrTimer: number | undefined
 
 const modeOptions = [
@@ -383,6 +407,7 @@ const proxySelectionInvalid = computed(() =>
   || (proxyStrategy.value === 'warp_pool' && availableWarpPoolCount.value === 0),
 )
 const proxyRouteLocked = computed(() => logging.value || hasActiveLoginSession.value)
+const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === deviceProfileKey.value))
 
 const stepIndex = computed(() => {
   if (currentStep.value === 'phone') return 0
@@ -472,6 +497,7 @@ async function next() {
       const response = await panelApi.startAccountLogin({
         phone: phone.value,
         loginId: loginId.value,
+        deviceProfileKey: deviceProfileKey.value || null,
         ...selectedProxyPayload(),
       })
       await handleLoginResponse(response)
@@ -514,6 +540,10 @@ async function next() {
 async function loadTelegramApiStatus() {
   try {
     const settings = await panelApi.settings()
+    deviceProfiles.value = settings.telegram.deviceProfiles || []
+    if (!deviceProfileKey.value) {
+      deviceProfileKey.value = settings.telegram.defaultDeviceProfileKey || deviceProfiles.value[0]?.key || ''
+    }
     const apiId = (settings.telegram.apiId || '').trim()
     const apiHash = (settings.telegram.apiHash || '').trim()
     const enabledProfile = (settings.telegram.profiles || []).find((profile) => {
@@ -558,6 +588,7 @@ async function startQrLogin() {
 
     const response = await panelApi.startAccountQrLogin({
       loginId: existingLoginId || undefined,
+      deviceProfileKey: deviceProfileKey.value || null,
       ...selectedProxyPayload(),
     })
     await handleQrResponse(response)
@@ -938,7 +969,8 @@ onMounted(async () => {
   min-width: 260px;
 }
 
-.login-proxy-route {
+.login-proxy-route,
+.login-device-profile {
   display: grid;
   gap: 12px;
   margin-bottom: 22px;
@@ -949,7 +981,8 @@ onMounted(async () => {
   background: var(--tp-panel);
 }
 
-.login-proxy-heading {
+.login-proxy-heading,
+.login-device-summary {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -966,8 +999,15 @@ onMounted(async () => {
   flex-wrap: wrap;
 }
 
-.login-proxy-select {
+.login-proxy-select,
+.login-device-select {
   width: 100%;
+}
+
+.login-device-summary {
+  color: var(--tp-muted);
+  font-size: 13px;
+  line-height: 1.6;
 }
 
 .login-proxy-notice {

--- a/frontend/src/views/AccountLogin.vue
+++ b/frontend/src/views/AccountLogin.vue
@@ -69,10 +69,10 @@
             show-icon
             class="mb-3"
           >
-            <template #title>未配置全局 Telegram API（ApiId/ApiHash），无法登录。</template>
+            <template #title>Telegram API 当前不可用，无法登录。</template>
             <div class="login-api-warning">
               <span>当前生效 ApiId：{{ effectiveApiId || '未配置' }}</span>
-              <el-button size="small" type="primary" @click="router.push('/settings')">去系统设置配置</el-button>
+              <el-button size="small" type="primary" @click="router.push('/telegram-api')">去 Telegram API 配置</el-button>
             </div>
           </el-alert>
 
@@ -187,10 +187,10 @@
             show-icon
             class="mb-3"
           >
-            <template #title>未配置全局 Telegram API（ApiId/ApiHash），无法登录。</template>
+            <template #title>Telegram API 当前不可用，无法登录。</template>
             <div class="login-api-warning">
               <span>当前生效 ApiId：{{ effectiveApiId || '未配置' }}</span>
-              <el-button size="small" type="primary" @click="router.push('/settings')">去系统设置配置</el-button>
+              <el-button size="small" type="primary" @click="router.push('/telegram-api')">去 Telegram API 配置</el-button>
             </div>
           </el-alert>
           <el-alert
@@ -457,7 +457,7 @@ async function loadLoginProxyOptions() {
 async function next() {
   if (logging.value) return
   if (currentStep.value === 'phone' && telegramApiChecked.value && !telegramApiConfigured.value) {
-    ElMessage.warning('请先配置全局 Telegram API')
+    ElMessage.warning('请先检查 Telegram API 配置')
     return
   }
   if (currentStep.value === 'phone' && !ensureProxySelected()) return
@@ -522,9 +522,11 @@ async function loadTelegramApiStatus() {
       return profile.enabled && !!profileApiId && !!profileApiHash
     })
     const profileApiId = (enabledProfile?.apiId || '').trim()
-    const effectiveApiIdFromSettings = (settings.system.effectiveApiId || '').trim()
+    const effectiveApiIdFromSettings = (settings.telegram.effectiveApiId || settings.system.effectiveApiId || '').trim()
     effectiveApiId.value = ((effectiveApiIdFromSettings !== '0' ? effectiveApiIdFromSettings : '') || (apiId !== '0' ? apiId : '') || profileApiId || '').trim()
-    telegramApiConfigured.value = (!!apiId && apiId !== '0' && !!apiHash) || !!enabledProfile
+    telegramApiConfigured.value = typeof settings.telegram.hasUsableApi === 'boolean'
+      ? settings.telegram.hasUsableApi
+      : ((!!apiId && apiId !== '0' && !!apiHash) || !!enabledProfile)
   } catch {
     telegramApiConfigured.value = true
   } finally {
@@ -535,7 +537,7 @@ async function loadTelegramApiStatus() {
 async function startQrLogin() {
   if (logging.value) return
   if (telegramApiChecked.value && !telegramApiConfigured.value) {
-    ElMessage.warning('请先配置全局 Telegram API')
+    ElMessage.warning('请先检查 Telegram API 配置')
     return
   }
   if (!ensureProxySelected()) return

--- a/frontend/src/views/TelegramApiSettings.vue
+++ b/frontend/src/views/TelegramApiSettings.vue
@@ -13,14 +13,24 @@
         <el-card shadow="never" class="page-card">
           <template #header>Telegram API 配置</template>
           <el-form label-position="top">
-            <el-form-item label="默认 API ID">
-              <el-input v-model="telegram.apiId" />
-              <div class="muted mt-2">Telegram 官方 API 的默认 ApiId；未启用 API 配置池时，新账号登录和导入将使用这里的 ApiId / ApiHash。</div>
+            <el-form-item label="自定义默认 API ID（可选）">
+              <el-input v-model="telegram.apiId" :placeholder="`留空使用内置官方 Android API ${officialApiId}`" />
+              <div class="muted mt-2">只有未启用 API 配置池时才使用；留空表示回退到内置官方 API。</div>
             </el-form-item>
-            <el-form-item label="默认 API Hash">
-              <el-input v-model="telegram.apiHash" />
-              <div class="muted mt-2">兼容旧配置；留空时会回退到启用的 API 配置池或账号已有的 ApiId / ApiHash。</div>
+            <el-form-item label="自定义默认 API Hash（可选）">
+              <el-input v-model="telegram.apiHash" type="password" show-password placeholder="留空使用内置官方 API Hash" />
+              <div class="muted mt-2">不需要手工填写官方 Hash；如需自建 API 或其他客户端 API 再填写。</div>
             </el-form-item>
+            <el-alert
+              class="official-api-alert mb-3"
+              :type="isBuiltInOfficialActive ? 'success' : 'info'"
+              :closable="false"
+              show-icon
+            >
+              <template #title>内置官方 Android API：ApiId {{ officialApiId }}{{ isBuiltInOfficialActive ? '（当前生效）' : '（可回退）' }}</template>
+              <div>ApiHash 已内置，默认不会写入 appsettings.local.json；只有自定义默认 API 和启用的 API 配置池都为空时使用。</div>
+              <div>当前来源：{{ effectiveApiSourceLabel }}</div>
+            </el-alert>
             <el-divider />
             <div class="section-title">API 配置池</div>
             <el-alert type="info" :closable="false" show-icon class="mb-3">
@@ -61,11 +71,12 @@
             </div>
             <el-button plain @click="addApiProfile">添加 API 配置</el-button>
           </el-form>
-          <el-alert type="info" :closable="false" show-icon class="mb-3">
+          <el-alert :type="settings?.telegram.hasUsableApi === false ? 'warning' : 'info'" :closable="false" show-icon class="mb-3">
             <template #title>Telegram API 状态</template>
             <div>写入位置：{{ settings?.localConfigPath || '-' }}</div>
             <div>文件存在：{{ settings?.localConfigExists ? '是' : '否' }}</div>
-            <div>当前生效 ApiId：{{ settings?.system.effectiveApiId || '（未配置）' }}</div>
+            <div>当前来源：{{ effectiveApiSourceLabel }}</div>
+            <div>当前生效 ApiId：{{ effectiveApiId || '（不可用）' }}</div>
           </el-alert>
           <el-button type="primary" :loading="saving.telegram" @click="saveTelegram">保存配置</el-button>
         </el-card>
@@ -73,19 +84,20 @@
 
       <div class="settings-column">
         <el-card shadow="never" class="page-card">
-          <template #header>官方 API 说明</template>
+          <template #header>内置官方 API 说明</template>
           <el-alert type="info" :closable="false" show-icon class="mb-3">
-            <template #title>未配置自定义 API 时，系统默认使用 Telegram 官方 Android API。</template>
-            <div>官方默认：ApiId {{ officialApiId }}；ApiHash 已内置，不需要手工填写。</div>
-            <div>如需其他官方客户端或自建 API，请在上方填写并保存；已有账号仍优先使用账号保存的 ApiId / ApiHash。</div>
+            <template #title>内置 API 是运行时回退，不是 appsettings.local.json 中的一条配置。</template>
+            <div>{{ officialApiName }}：ApiId {{ officialApiId }}；ApiHash 已内置，不需要手工填写。</div>
+            <div>如果当前来源不是内置，说明仍有自定义默认 API 或启用的 API 配置池在覆盖它。</div>
           </el-alert>
           <el-descriptions :column="1" border size="small">
-            <el-descriptions-item label="官方默认 ApiId">{{ officialApiId }}</el-descriptions-item>
-            <el-descriptions-item label="当前默认 ApiId">{{ telegram.apiId || officialApiId }}</el-descriptions-item>
-            <el-descriptions-item label="启用中的 API 配置">{{ telegram.profiles.filter((profile) => profile.enabled !== false).length }}</el-descriptions-item>
+            <el-descriptions-item label="内置官方 ApiId">{{ officialApiId }}</el-descriptions-item>
+            <el-descriptions-item label="当前来源">{{ effectiveApiSourceLabel }}</el-descriptions-item>
+            <el-descriptions-item label="当前生效 ApiId">{{ effectiveApiId || '（不可用）' }}</el-descriptions-item>
+            <el-descriptions-item label="启用中的 API 配置">{{ enabledApiProfiles.length }}</el-descriptions-item>
           </el-descriptions>
           <div class="button-row mt-3">
-            <el-button plain @click="useOfficialApi">恢复官方默认</el-button>
+            <el-button plain @click="useBuiltInOfficialApiFallback">改用内置官方 API</el-button>
           </div>
         </el-card>
 
@@ -95,13 +107,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { panelApi } from '@/api/panel'
 import type { SettingsPayload, TelegramApiSettings, TelegramApiProfile } from '@/api/types'
 
-const officialApiId = '6'
-const officialApiHash = 'eb06d4abfb49dc3eeb1aeb98ae0f581e'
+const fallbackOfficialApiId = '6'
+const fallbackOfficialApiName = 'Telegram 官方 Android API'
 const settings = ref<SettingsPayload | null>(null)
 const telegram = reactive({
   apiId: '',
@@ -112,10 +124,23 @@ const saving = reactive({
   telegram: false,
 })
 
+const officialApiId = computed(() => settings.value?.telegram.officialApiId || fallbackOfficialApiId)
+const officialApiName = computed(() => settings.value?.telegram.officialApiName || fallbackOfficialApiName)
+const enabledApiProfiles = computed(() => telegram.profiles.filter((profile) => profile.enabled !== false))
+const effectiveApiId = computed(() => settings.value?.telegram.effectiveApiId || settings.value?.system.effectiveApiId || '')
+const effectiveApiSourceLabel = computed(() => {
+  const source = settings.value?.telegram.effectiveApiSource
+  if (source === 'built_in_official') return '内置官方 Android API'
+  if (source === 'api_profile') return settings.value?.telegram.effectiveApiName || 'API 配置池'
+  if (source === 'custom_default') return '自定义默认 API'
+  if (source === 'invalid') return '配置不可用'
+  return settings.value ? '未配置' : '加载中'
+})
+const isBuiltInOfficialActive = computed(() => settings.value?.telegram.effectiveApiSource === 'built_in_official')
+
 function normalizeTelegramSettings(source: TelegramApiSettings) {
-  const hasProfiles = (source.profiles?.some((profile) => profile.enabled !== false) || false)
-  telegram.apiId = !source.apiId || source.apiId === '0' ? (hasProfiles ? '' : officialApiId) : source.apiId
-  telegram.apiHash = source.apiHash || (hasProfiles ? '' : officialApiHash)
+  telegram.apiId = !source.apiId || source.apiId === '0' ? '' : source.apiId
+  telegram.apiHash = source.apiHash || ''
   const profiles = source.profiles || []
   telegram.profiles = profiles.map((profile) => ({
     name: profile.name || '',
@@ -151,10 +176,20 @@ async function saveTelegram() {
   }
 }
 
-function useOfficialApi() {
-  telegram.apiId = officialApiId
-  telegram.apiHash = officialApiHash
-  ElMessage.info('已恢复官方默认 API；点击保存配置后生效')
+function hasSavableProfile(profile: TelegramApiProfile) {
+  return !!(profile.apiId?.trim() && profile.apiHash?.trim())
+}
+
+function useBuiltInOfficialApiFallback() {
+  const enabledCount = telegram.profiles.filter((profile) => profile.enabled !== false).length
+  telegram.apiId = ''
+  telegram.apiHash = ''
+  telegram.profiles = telegram.profiles
+    .filter(hasSavableProfile)
+    .map((profile) => ({ ...profile, enabled: false }))
+  ElMessage.info(enabledCount > 0
+    ? '已清空自定义默认 API 并停用 API 配置池；点击保存配置后使用内置官方 API'
+    : '已清空自定义默认 API；点击保存配置后使用内置官方 API')
 }
 
 function addApiProfile() {
@@ -213,6 +248,10 @@ onMounted(load)
   border-radius: 8px;
   padding: 12px;
   margin-bottom: 12px;
+}
+
+.official-api-alert {
+  margin-top: 4px;
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/views/TelegramDeviceProfiles.vue
+++ b/frontend/src/views/TelegramDeviceProfiles.vue
@@ -66,10 +66,11 @@
           <template #header>Telegram API 入口</template>
           <el-alert type="info" :closable="false" show-icon class="mb-3">
             <template #title>默认官方 API 和 API 配置池在独立的 Telegram API 页面管理。</template>
-            <div>这里读取当前默认 ApiId、已启用 API 配置池数量和默认设备指纹，便于你确认这两块是否已经生效。</div>
+            <div>这里读取当前生效 ApiId、API 来源、已启用 API 配置池数量和默认设备指纹，便于你确认这两块是否已经生效。</div>
           </el-alert>
           <el-descriptions :column="1" border size="small">
-            <el-descriptions-item label="当前默认 ApiId">{{ settings?.telegram.apiId || '（未配置）' }}</el-descriptions-item>
+            <el-descriptions-item label="当前生效 ApiId">{{ effectiveApiId || '（不可用）' }}</el-descriptions-item>
+            <el-descriptions-item label="当前 API 来源">{{ effectiveApiSourceLabel }}</el-descriptions-item>
             <el-descriptions-item label="启用中的 API 配置">{{ enabledApiProfiles.length }}</el-descriptions-item>
             <el-descriptions-item label="当前默认设备指纹">
               {{ selectedDeviceProfile ? `${selectedDeviceProfile.name} · ${selectedDeviceProfile.family}` : '（未配置）' }}
@@ -100,6 +101,15 @@ const saving = ref(false)
 
 const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === defaultDeviceProfileKey.value))
 const enabledApiProfiles = computed(() => (settings.value?.telegram.profiles || []).filter((profile) => profile.enabled !== false))
+const effectiveApiId = computed(() => settings.value?.telegram.effectiveApiId || settings.value?.system.effectiveApiId || '')
+const effectiveApiSourceLabel = computed(() => {
+  const source = settings.value?.telegram.effectiveApiSource
+  if (source === 'built_in_official') return '内置官方 Android API'
+  if (source === 'api_profile') return settings.value?.telegram.effectiveApiName || 'API 配置池'
+  if (source === 'custom_default') return '自定义默认 API'
+  if (source === 'invalid') return '配置不可用'
+  return settings.value ? '未配置' : '加载中'
+})
 
 function normalizeTelegramSettings(source: TelegramApiSettings) {
   deviceProfiles.value = source.deviceProfiles || []

--- a/frontend/tests/accountLoginProxyRoute.test.mjs
+++ b/frontend/tests/accountLoginProxyRoute.test.mjs
@@ -38,6 +38,13 @@ test('任一登录模式存在会话时都保持出口和模式锁定', () => {
   assert.match(source, /:disabled="logging \|\| hasActiveLoginSession"/)
 })
 
+test('手动登录在首次连接前选择并锁定设备指纹', () => {
+  assert.match(source, /本次登录设备指纹/)
+  assert.match(source, /deviceProfiles = ref<TelegramDeviceProfile\[\]>\(\[\]\)/)
+  assert.match(source, /deviceProfileKey: deviceProfileKey\.value \|\| null/)
+  assert.match(source, /:disabled="proxyRouteLocked"/)
+})
+
 test('重新生成二维码时复用冻结路由而不是先取消登录会话', () => {
   const body = functionBody('startQrLogin', 'pollQrLogin')
 

--- a/frontend/tests/accountStatusDisplay.test.mjs
+++ b/frontend/tests/accountStatusDisplay.test.mjs
@@ -6,6 +6,7 @@ const statusSource = await readFile(new URL('../src/utils/telegramStatus.ts', im
 const accountsSource = await readFile(new URL('../src/views/Accounts.vue', import.meta.url), 'utf8')
 const accountImportSource = await readFile(new URL('../src/views/AccountImport.vue', import.meta.url), 'utf8')
 const accountLoginSource = await readFile(new URL('../src/views/AccountLogin.vue', import.meta.url), 'utf8')
+const telegramApiSettingsSource = await readFile(new URL('../src/views/TelegramApiSettings.vue', import.meta.url), 'utf8')
 
 
 test('临时 Telegram 网络错误与账号失效分开展示', () => {
@@ -39,10 +40,17 @@ test('导入页只展示已导入账号并引导去账号列表操作', () => {
   assert.doesNotMatch(accountImportSource, /handleBatchCommand/)
 })
 
-test('导入和登录页把启用的 API 配置池视为可用 Telegram API', () => {
+test('导入和登录页使用服务端有效 API 状态', () => {
   for (const source of [accountImportSource, accountLoginSource]) {
-    assert.match(source, /settings\.telegram\.profiles \|\| \[\]/)
-    assert.match(source, /profile\.enabled && !!profileApiId && !!profileApiHash/)
-    assert.match(source, /telegramApiConfigured\.value = \(!!apiId && apiId !== '0' && !!apiHash\) \|\| !!enabledProfile/)
+    assert.match(source, /settings\.telegram\.effectiveApiId \|\| settings\.system\.effectiveApiId/)
+    assert.match(source, /typeof settings\.telegram\.hasUsableApi === 'boolean'/)
+    assert.match(source, /\? settings\.telegram\.hasUsableApi/)
   }
+})
+
+test('Telegram API 页面明确展示内置官方 API 回退', () => {
+  assert.match(telegramApiSettingsSource, /内置官方 Android API：ApiId/)
+  assert.match(telegramApiSettingsSource, /改用内置官方 API/)
+  assert.match(telegramApiSettingsSource, /effectiveApiSource === 'built_in_official'/)
+  assert.match(telegramApiSettingsSource, /ApiHash 已内置/)
 })

--- a/frontend/tests/mainLayoutMenu.test.mjs
+++ b/frontend/tests/mainLayoutMenu.test.mjs
@@ -10,11 +10,11 @@ test('侧栏子菜单默认全部收起', () => {
   assert.equal(source.match(/:default-openeds="defaultOpeneds"/g)?.length, 2)
 })
 
-test('Telegram API 和设备指纹作为独立侧栏页面', async () => {
+test('Telegram API 和设备指纹作为侧栏独立入口', async () => {
   const routerSource = await readFile(new URL('../src/router/index.ts', import.meta.url), 'utf8')
-  assert.match(source, /label: 'Telegram 设置'/)
   assert.match(source, /label: 'Telegram API'/)
   assert.match(source, /label: '设备指纹'/)
+  assert.doesNotMatch(source, /label: 'Telegram 设置'/)
   assert.match(routerSource, /path: 'telegram-api'/)
   assert.match(routerSource, /path: 'device-profiles'/)
 })

--- a/src/TelegramPanel.Core/Interfaces/IAccountService.cs
+++ b/src/TelegramPanel.Core/Interfaces/IAccountService.cs
@@ -15,7 +15,8 @@ public interface IAccountService
         int accountId,
         string phone,
         AccountProxyResolution proxyResolution,
-        TelegramApiCredentials apiCredentials);
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey = null);
 
     /// <summary>
     /// 使用登录前已明确选择的路由发起二维码登录。
@@ -23,7 +24,8 @@ public interface IAccountService
     Task<QrLoginResult> StartQrLoginAsync(
         int loginId,
         AccountProxyResolution proxyResolution,
-        TelegramApiCredentials apiCredentials);
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey = null);
 
     /// <summary>
     /// 查询二维码登录状态。

--- a/src/TelegramPanel.Core/Services/Telegram/AccountService.cs
+++ b/src/TelegramPanel.Core/Services/Telegram/AccountService.cs
@@ -35,17 +35,19 @@ public class AccountService : IAccountService
         int accountId,
         string phone,
         AccountProxyResolution proxyResolution,
-        TelegramApiCredentials apiCredentials)
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey = null)
     {
         ArgumentNullException.ThrowIfNull(proxyResolution);
-        return StartLoginCoreAsync(accountId, phone, proxyResolution, apiCredentials);
+        return StartLoginCoreAsync(accountId, phone, proxyResolution, apiCredentials, deviceProfileKey);
     }
 
     private async Task<LoginResult> StartLoginCoreAsync(
         int accountId,
         string phone,
         AccountProxyResolution proxyOverride,
-        TelegramApiCredentials apiCredentials)
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey)
     {
         if (!TelegramApiProfilePool.TryNormalizeCredentials(apiCredentials.ApiId, apiCredentials.ApiHash, out var apiHash, out var apiHashReason))
         {
@@ -146,22 +148,25 @@ public class AccountService : IAccountService
                 apiHash,
                 normalizedPhone,
                 null,
-                proxyOverride);
+                proxyOverride,
+                deviceProfileKey);
     }
 
     public Task<QrLoginResult> StartQrLoginAsync(
         int loginId,
         AccountProxyResolution proxyResolution,
-        TelegramApiCredentials apiCredentials)
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey = null)
     {
         ArgumentNullException.ThrowIfNull(proxyResolution);
-        return StartQrLoginCoreAsync(loginId, proxyResolution, apiCredentials);
+        return StartQrLoginCoreAsync(loginId, proxyResolution, apiCredentials, deviceProfileKey);
     }
 
     private async Task<QrLoginResult> StartQrLoginCoreAsync(
         int loginId,
         AccountProxyResolution proxyOverride,
-        TelegramApiCredentials apiCredentials)
+        TelegramApiCredentials apiCredentials,
+        string? deviceProfileKey)
     {
         if (loginId <= 0)
             loginId = Random.Shared.Next(1, int.MaxValue);
@@ -178,7 +183,7 @@ public class AccountService : IAccountService
         await CancelQrLoginStrictAsync(loginId);
 
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
-        var session = new QrLoginSession(loginId, tempPath, apiId, apiHash, cts);
+        var session = new QrLoginSession(loginId, tempPath, apiId, apiHash, cts, deviceProfileKey);
         if (!QrLoginSessions.TryAdd(loginId, session))
         {
             cts.Dispose();
@@ -193,7 +198,8 @@ public class AccountService : IAccountService
                 tempPath,
                 apiHash,
                 session.WaitForPassword,
-                proxyOverride);
+                proxyOverride,
+                session.DeviceProfileKey);
             session.LoginTask = RunQrLoginAsync(session);
 
             for (var i = 0; i < 40; i++)
@@ -638,7 +644,8 @@ public class AccountService : IAccountService
         string sessionPath,
         string sessionKey,
         Func<string>? passwordProvider,
-        AccountProxyResolution proxyOverride)
+        AccountProxyResolution proxyOverride,
+        string? deviceProfileKey = null)
     {
         ArgumentNullException.ThrowIfNull(proxyOverride);
         var accountProxy = proxyOverride.Proxy
@@ -646,7 +653,7 @@ public class AccountService : IAccountService
                                ? throw new InvalidOperationException(
                                    "全局代理路由未在首次连接前解析，已阻止降级为直连")
                                : null);
-        var deviceProfile = TelegramClientDeviceProfile.ForStableKey(apiId, $"{apiId}:{sessionPath}");
+        var deviceProfile = TelegramDeviceProfileCatalog.ResolveClientProfile(_configuration, apiId, deviceProfileKey, $"{apiId}:{sessionPath}");
 
         string Config(string what)
         {
@@ -820,13 +827,14 @@ public class AccountService : IAccountService
 
     private sealed class QrLoginSession
     {
-        public QrLoginSession(int loginId, string tempSessionPath, int apiId, string apiHash, CancellationTokenSource cancellation)
+        public QrLoginSession(int loginId, string tempSessionPath, int apiId, string apiHash, CancellationTokenSource cancellation, string? deviceProfileKey)
         {
             LoginId = loginId;
             TempSessionPath = tempSessionPath;
             ApiId = apiId;
             ApiHash = apiHash;
             Cancellation = cancellation;
+            DeviceProfileKey = deviceProfileKey;
             ExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(5);
         }
 
@@ -834,6 +842,7 @@ public class AccountService : IAccountService
         public string TempSessionPath { get; }
         public int ApiId { get; }
         public string ApiHash { get; }
+        public string? DeviceProfileKey { get; }
         public CancellationTokenSource Cancellation { get; }
         public SemaphoreSlim LifecycleLock { get; } = new(1, 1);
         public WTelegram.Client? Client { get; set; }

--- a/src/TelegramPanel.Core/Services/Telegram/TelegramApiProfilePool.cs
+++ b/src/TelegramPanel.Core/Services/Telegram/TelegramApiProfilePool.cs
@@ -60,7 +60,7 @@ public sealed class TelegramApiProfilePool
             if (TryGetGlobalFallback(_configuration, out var fallback))
                 return fallback;
 
-            throw new InvalidOperationException("请先在【系统设置】中配置全局 Telegram API（ApiId/ApiHash）或至少一个启用的 API 配置");
+            throw new InvalidOperationException("请先在【Telegram 设置 → Telegram API】中配置全局 Telegram API（ApiId/ApiHash）或至少一个启用的 API 配置");
         }
 
         var usage = new int[profiles.Count];
@@ -181,7 +181,7 @@ public sealed class TelegramApiProfilePool
             return true;
         }
 
-        error = "请先在【系统设置】中配置全局 Telegram API（ApiId/ApiHash）或至少一个启用的 API 配置";
+        error = "请先在【Telegram 设置 → Telegram API】中配置全局 Telegram API（ApiId/ApiHash）或至少一个启用的 API 配置";
         return false;
     }
 

--- a/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
+++ b/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
@@ -2009,7 +2009,8 @@ public static class PanelAdminApiEndpoints
                     loginId,
                     request.ProxyStrategy,
                     request.ProxyId,
-                    cancellationToken);
+                    cancellationToken,
+                    request.DeviceProfileKey);
             }
         }
         catch (Exception ex) when (IsLoginProxyInputError(ex))
@@ -2047,7 +2048,8 @@ public static class PanelAdminApiEndpoints
                 loginId,
                 phone,
                 proxyState.Resolution,
-                apiCredentials);
+                apiCredentials,
+                proxyState.DeviceProfileKey);
         }
         catch (Exception ex) when (IsLoginProxyInputError(ex))
         {
@@ -2143,7 +2145,8 @@ public static class PanelAdminApiEndpoints
                     loginId,
                     request.ProxyStrategy,
                     request.ProxyId,
-                    cancellationToken);
+                    cancellationToken,
+                    request.DeviceProfileKey);
             }
         }
         catch (Exception ex) when (IsLoginProxyInputError(ex))
@@ -2165,7 +2168,8 @@ public static class PanelAdminApiEndpoints
             result = await accountService.StartQrLoginAsync(
                 loginId,
                 proxyState.Resolution,
-                apiCredentials);
+                apiCredentials,
+                proxyState.DeviceProfileKey);
         }
         catch
         {
@@ -6805,6 +6809,8 @@ public static class PanelAdminApiEndpoints
                     null));
             }
 
+            var deviceProfileKey = loginProxy.GetDeviceProfileKey(loginId);
+
             Account? account = null;
             try
             {
@@ -6813,7 +6819,8 @@ public static class PanelAdminApiEndpoints
                     accountManagement,
                     configuration,
                     twoFactorPasswordToSave,
-                    activate: false);
+                    activate: false,
+                    deviceProfileKey: deviceProfileKey);
                 await loginProxy.CompleteAsync(
                     loginId,
                     account.Id,
@@ -6932,6 +6939,8 @@ public static class PanelAdminApiEndpoints
                     null));
             }
 
+            var deviceProfileKey = loginProxy.GetDeviceProfileKey(result.LoginId);
+
             Account? account = null;
             try
             {
@@ -6940,7 +6949,8 @@ public static class PanelAdminApiEndpoints
                     accountManagement,
                     configuration,
                     twoFactorPasswordToSave,
-                    activate: false);
+                    activate: false,
+                    deviceProfileKey: deviceProfileKey);
                 await loginProxy.CompleteAsync(
                     result.LoginId,
                     account.Id,
@@ -7010,7 +7020,8 @@ public static class PanelAdminApiEndpoints
         AccountManagementService accountManagement,
         IConfiguration configuration,
         string? twoFactorPasswordToSave = null,
-        bool activate = true)
+        bool activate = true,
+        string? deviceProfileKey = null)
     {
         int apiId;
         string apiHash;
@@ -7023,6 +7034,11 @@ public static class PanelAdminApiEndpoints
         {
             throw new InvalidOperationException(apiError);
         }
+        var selectedDeviceProfile = TelegramDeviceProfileCatalog.Find(configuration, deviceProfileKey);
+        if (!string.IsNullOrWhiteSpace(deviceProfileKey) && selectedDeviceProfile == null)
+            throw new InvalidOperationException("登录设备指纹不存在或已停用");
+        var savedDeviceProfileKey = selectedDeviceProfile?.Key ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration);
+
 
         var sessionsPath = configuration["Telegram:SessionsPath"] ?? "sessions";
         var phoneDigits = PhoneNumberFormatter.NormalizeToDigits(accountInfo.Phone);
@@ -7040,8 +7056,7 @@ public static class PanelAdminApiEndpoints
             existing.IsActive = activate;
             existing.ApiId = apiId;
             existing.ApiHash = apiHash;
-            if (string.IsNullOrWhiteSpace(existing.DeviceProfileKey))
-                existing.DeviceProfileKey = TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration);
+            existing.DeviceProfileKey = savedDeviceProfileKey;
             existing.TelegramStatusSummary = "正常";
             existing.TelegramStatusDetails = null;
             existing.TelegramStatusOk = true;
@@ -7063,7 +7078,7 @@ public static class PanelAdminApiEndpoints
             SessionPath = Path.Combine(sessionsPath, $"{phoneDigits}.session"),
             ApiId = apiId,
             ApiHash = apiHash,
-            DeviceProfileKey = TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration),
+            DeviceProfileKey = savedDeviceProfileKey,
             IsActive = activate,
             TwoFactorPassword = normalizedTwoFactorPassword,
             CreatedAt = DateTime.UtcNow,
@@ -8081,11 +8096,13 @@ public sealed record StartAccountLoginRequestDto(
     string? Phone,
     int LoginId = 0,
     string? ProxyStrategy = null,
-    int? ProxyId = null);
+    int? ProxyId = null,
+    string? DeviceProfileKey = null);
 public sealed record StartAccountQrLoginRequestDto(
     int LoginId = 0,
     string? ProxyStrategy = null,
-    int? ProxyId = null);
+    int? ProxyId = null,
+    string? DeviceProfileKey = null);
 public sealed record AccountLoginSessionRequestDto(int LoginId);
 public sealed record AccountLoginCodeRequestDto(int LoginId, string? Code);
 public sealed record AccountLoginPasswordRequestDto(int LoginId, string? Password, bool? SaveTwoFactorPassword = null);

--- a/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
+++ b/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
@@ -2385,15 +2385,22 @@ public static class PanelAdminApiEndpoints
         var localPath = LocalConfigFile.ResolvePath(configuration, environment);
         var tz = timeZone.Current;
         var offset = tz.BaseUtcOffset >= TimeSpan.Zero ? "+" + tz.BaseUtcOffset.ToString(@"hh\:mm") : "-" + tz.BaseUtcOffset.Duration().ToString(@"hh\:mm");
+        var telegramApiStatus = ReadTelegramApiRuntimeStatus(configuration);
         var dto = new SettingsDto(
             LocalConfigPath: localPath,
             LocalConfigExists: File.Exists(localPath),
             Telegram: new TelegramApiSettingsDto(
-                ReadEffectiveTelegramApiId(configuration),
-                ReadEffectiveTelegramApiHash(configuration),
+                ReadConfiguredTelegramApiId(configuration),
+                ReadConfiguredTelegramApiHash(configuration),
                 ReadTelegramApiProfiles(configuration),
                 TelegramDeviceProfileCatalog.ReadProfiles(configuration).Select(ToDto).ToList(),
-                TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration)),
+                TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration),
+                telegramApiStatus.EffectiveApiId,
+                telegramApiStatus.EffectiveApiSource,
+                telegramApiStatus.EffectiveApiName,
+                TelegramApiProfilePool.OfficialAndroidApiId.ToString(CultureInfo.InvariantCulture),
+                TelegramApiProfilePool.OfficialAndroidApiName,
+                telegramApiStatus.HasUsableApi),
             GlobalProxy: ReadGlobalProxySettings(configuration),
             CloudMail: new CloudMailSettingsDto(configuration["CloudMail:BaseUrl"] ?? "", configuration["CloudMail:Domain"] ?? "", configuration["CloudMail:Token"] ?? ""),
             Ai: new AiSettingsDto(
@@ -2418,7 +2425,7 @@ public static class PanelAdminApiEndpoints
                 configuration.GetValue("TelegramStatus:AutoRefreshDelayMs", 5000)),
             Logging: new LoggingSettingsDto(configuration.GetValue("Serilog:Enabled", false), configuration["Serilog:MinimumLevel:Default"] ?? "Information", configuration.GetValue("Serilog:RetainedFileCountLimit", 30)),
             TimeZone: new TimeZoneSettingsDto(configuration["System:TimeZoneId"] ?? "", $"{tz.Id}（UTC{offset}）"),
-            System: new SystemInfoSettingsDto(VersionService.Version, ".NET 8.0", "SQLite", ReadEffectiveTelegramApiId(configuration)));
+            System: new SystemInfoSettingsDto(VersionService.Version, ".NET 8.0", "SQLite", telegramApiStatus.EffectiveApiId));
 
         return Task.FromResult<IResult>(Results.Ok(dto));
     }
@@ -2486,10 +2493,6 @@ public static class PanelAdminApiEndpoints
                 return Results.BadRequest(new OperationResultDto(false, $"默认 API Hash 无效：{reason}"));
             request = request with { ApiId = apiId.ToString(CultureInfo.InvariantCulture), ApiHash = apiHash };
         }
-        else if (profiles.All(profile => !profile.Enabled))
-        {
-            return Results.BadRequest(new OperationResultDto(false, "请至少配置默认 API 或启用一个 API 配置"));
-        }
         var root = await LoadLocalConfigRootAsync(LocalConfigFile.ResolvePath(configuration, environment));
         var telegram = EnsureObject(root, "Telegram");
         if (hasDefaultApi)
@@ -2546,25 +2549,48 @@ public static class PanelAdminApiEndpoints
                 profile.Notes))
             .ToList();
 
-    private static string ReadEffectiveTelegramApiId(IConfiguration configuration)
-    {
-        if (TelegramApiProfilePool.GetEnabledProfiles(configuration).Count > 0)
-            return configuration["Telegram:ApiId"] ?? string.Empty;
+    internal sealed record TelegramApiRuntimeStatus(
+        string EffectiveApiId,
+        string EffectiveApiSource,
+        string EffectiveApiName,
+        bool HasUsableApi);
 
-        return TelegramApiProfilePool.TryGetGlobalFallback(configuration, out var credentials)
-            ? credentials.ApiId.ToString(CultureInfo.InvariantCulture)
-            : configuration["Telegram:ApiId"] ?? string.Empty;
+    internal static TelegramApiRuntimeStatus ReadTelegramApiRuntimeStatus(IConfiguration configuration)
+    {
+        var profiles = TelegramApiProfilePool.GetEnabledProfiles(configuration);
+        if (profiles.Count > 0)
+        {
+            var profile = profiles[0];
+            return new TelegramApiRuntimeStatus(
+                profile.ApiId.ToString(CultureInfo.InvariantCulture),
+                "api_profile",
+                profile.Name,
+                true);
+        }
+
+        if (TelegramApiProfilePool.TryGetGlobalFallback(configuration, out var credentials))
+        {
+            var isOfficialAndroid = credentials.ApiId == TelegramApiProfilePool.OfficialAndroidApiId
+                && string.Equals(credentials.ApiHash, TelegramApiProfilePool.OfficialAndroidApiHash, StringComparison.OrdinalIgnoreCase);
+            return new TelegramApiRuntimeStatus(
+                credentials.ApiId.ToString(CultureInfo.InvariantCulture),
+                isOfficialAndroid ? "built_in_official" : "custom_default",
+                credentials.ProfileName ?? (isOfficialAndroid ? TelegramApiProfilePool.OfficialAndroidApiName : "默认 API"),
+                true);
+        }
+
+        var configuredApiId = ReadConfiguredTelegramApiId(configuration);
+        return new TelegramApiRuntimeStatus(configuredApiId, "invalid", "不可用", false);
     }
 
-    private static string ReadEffectiveTelegramApiHash(IConfiguration configuration)
+    private static string ReadConfiguredTelegramApiId(IConfiguration configuration)
     {
-        if (TelegramApiProfilePool.ReadConfiguredProfiles(configuration).Count > 0)
-            return configuration["Telegram:ApiHash"] ?? string.Empty;
-
-        return TelegramApiProfilePool.TryGetGlobalFallback(configuration, out var credentials)
-            ? credentials.ApiHash
-            : configuration["Telegram:ApiHash"] ?? string.Empty;
+        var configuredApiId = (configuration["Telegram:ApiId"] ?? string.Empty).Trim();
+        return configuredApiId == "0" ? string.Empty : configuredApiId;
     }
+
+    private static string ReadConfiguredTelegramApiHash(IConfiguration configuration) =>
+        configuration["Telegram:ApiHash"] ?? string.Empty;
 
     private static IReadOnlyList<TelegramApiProfile> NormalizeTelegramApiProfiles(
         IReadOnlyList<TelegramApiProfileDto>? profiles,
@@ -8272,7 +8298,13 @@ public sealed record TelegramApiSettingsDto(
     string ApiHash,
     IReadOnlyList<TelegramApiProfileDto>? Profiles = null,
     IReadOnlyList<TelegramDeviceProfileDto>? DeviceProfiles = null,
-    string? DefaultDeviceProfileKey = null);
+    string? DefaultDeviceProfileKey = null,
+    string? EffectiveApiId = null,
+    string? EffectiveApiSource = null,
+    string? EffectiveApiName = null,
+    string? OfficialApiId = null,
+    string? OfficialApiName = null,
+    bool HasUsableApi = true);
 public sealed record TelegramApiProfileDto(string? Name, string? ApiId, string? ApiHash, bool Enabled = true, int Weight = 1, string? Notes = null);
 public sealed record TelegramDeviceProfileDto(
     string Key,

--- a/src/TelegramPanel.Web/Services/AccountLoginProxyCoordinator.cs
+++ b/src/TelegramPanel.Web/Services/AccountLoginProxyCoordinator.cs
@@ -6,6 +6,7 @@ using TelegramPanel.Core.Models;
 using TelegramPanel.Core.Services;
 using TelegramPanel.Core.Services.Proxy;
 using TelegramPanel.Core.Utils;
+using TelegramPanel.Core.Services.Telegram;
 using TelegramPanel.Data.Entities;
 
 namespace TelegramPanel.Web.Services;
@@ -22,7 +23,8 @@ public sealed record AccountLoginProxyState(
     int? OwnedWarpProxyId,
     ResinLeaseControlSnapshot? ResinLease,
     string? TemporaryResinKey,
-    DateTimeOffset CreatedAtUtc);
+    DateTimeOffset CreatedAtUtc,
+    string? DeviceProfileKey = null);
 
 /// <summary>
 /// 临时独占一个仍在字典中的冻结路由，释放前过期清理和完成流程都不能取得它。
@@ -65,6 +67,12 @@ public sealed class AccountLoginProxyStateStore : IWarpProxyUsageGuard
 
         lock (_stateGate)
             return _states.ContainsKey(loginId);
+    }
+
+    public bool TryGet(int loginId, out AccountLoginProxyState? state)
+    {
+        lock (_stateGate)
+            return _states.TryGetValue(loginId, out state);
     }
 
     public bool OwnsWarpProxy(int proxyId)
@@ -440,6 +448,9 @@ public sealed class AccountLoginProxyCoordinator
 
     public bool HasState(int loginId) => _store.Contains(loginId);
 
+    public string? GetDeviceProfileKey(int loginId) =>
+        _store.TryGet(loginId, out var state) ? state?.DeviceProfileKey : null;
+
     /// <summary>
     /// 复用已经冻结的登录出口。客户端提交的选择必须与首次选择完全一致。
     /// </summary>
@@ -521,7 +532,8 @@ public sealed class AccountLoginProxyCoordinator
         int loginId,
         string? strategy,
         int? proxyId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? deviceProfileKey = null)
     {
         if (loginId <= 0)
             throw new ArgumentOutOfRangeException(nameof(loginId));
@@ -542,6 +554,11 @@ public sealed class AccountLoginProxyCoordinator
         ResinLeaseControlSnapshot? resinLease = null;
         string? temporaryResinKey = null;
         int? ownedWarpProxyId = null;
+        var selectedDeviceProfile = TelegramDeviceProfileCatalog.Find(_configuration, deviceProfileKey);
+        if (!string.IsNullOrWhiteSpace(deviceProfileKey) && selectedDeviceProfile == null)
+            throw new ArgumentException("登录设备指纹不存在或已停用");
+        var normalizedDeviceProfileKey = selectedDeviceProfile?.Key ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(_configuration);
+
         IDisposable? warpRequestClaim = null;
 
         switch (normalizedStrategy)
@@ -661,7 +678,8 @@ public sealed class AccountLoginProxyCoordinator
             ownedWarpProxyId,
             resinLease,
             temporaryResinKey,
-            DateTimeOffset.UtcNow);
+            DateTimeOffset.UtcNow,
+            normalizedDeviceProfileKey);
         try
         {
             if (!_store.TryAdd(state, out var stateError))

--- a/tests/TelegramPanel.Web.Tests/ManualLoginProxyRoutingTests.cs
+++ b/tests/TelegramPanel.Web.Tests/ManualLoginProxyRoutingTests.cs
@@ -54,7 +54,8 @@ public sealed class ManualLoginProxyRoutingTests
                 sessionPath,
                 "0123456789abcdef0123456789abcdef",
                 null,
-                new AccountProxyResolution(proxy, false)
+                new AccountProxyResolution(proxy, false),
+                null
             })!;
 
             Assert.NotNull(client.TcpHandler);
@@ -86,6 +87,7 @@ public sealed class ManualLoginProxyRoutingTests
                 "0123456789abcdef0123456789abcdef",
                 Path.Combine(Path.GetTempPath(), $"telegram-panel-null-route-{Guid.NewGuid():N}.session"),
                 "0123456789abcdef0123456789abcdef",
+                null,
                 null,
                 null
             }));
@@ -703,6 +705,37 @@ public sealed class ManualLoginProxyRoutingTests
         Assert.Same(original.Resolution, restored?.Resolution);
         Assert.False(store.TryClaimExisting(1702, out _));
         store.ReleaseLoginClaim(1702);
+    }
+
+    [Fact]
+    public async Task 手动登录首次连接会冻结设备指纹Key()
+    {
+        await using var fixture = await Fixture.CreateAsync(new Dictionary<string, string?>
+        {
+            ["Telegram:DefaultDeviceProfileKey"] = "custom-android",
+            ["Telegram:DeviceProfiles:0:Key"] = "custom-android",
+            ["Telegram:DeviceProfiles:0:Name"] = "Custom Android",
+            ["Telegram:DeviceProfiles:0:Family"] = "android",
+            ["Telegram:DeviceProfiles:0:AppVersion"] = "99.1",
+            ["Telegram:DeviceProfiles:0:DeviceModel"] = "Custom Phone",
+            ["Telegram:DeviceProfiles:0:SystemVersion"] = "Android 99",
+            ["Telegram:DeviceProfiles:0:SystemLangCode"] = "zh-CN",
+            ["Telegram:DeviceProfiles:0:LangCode"] = "zh",
+            ["Telegram:DeviceProfiles:0:Enabled"] = "true"
+        });
+
+        var state = await fixture.Coordinator.PrepareAsync(
+            1801,
+            "direct",
+            null,
+            CancellationToken.None,
+            "custom-android");
+
+        Assert.Equal("custom-android", state.DeviceProfileKey);
+        Assert.Equal("custom-android", fixture.Coordinator.GetDeviceProfileKey(1801));
+
+        await fixture.Coordinator.AbandonAsync(1801);
+        Assert.False(fixture.Coordinator.HasState(1801));
     }
 
     private sealed class Fixture : IAsyncDisposable

--- a/tests/TelegramPanel.Web.Tests/TelegramApiProfilePoolTests.cs
+++ b/tests/TelegramPanel.Web.Tests/TelegramApiProfilePoolTests.cs
@@ -86,6 +86,40 @@ public sealed class TelegramApiProfilePoolTests
     }
 
     [Fact]
+    public void ReadTelegramApiRuntimeStatus_ExposesBuiltInOfficialFallback()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var status = PanelAdminApiEndpoints.ReadTelegramApiRuntimeStatus(configuration);
+
+        Assert.True(status.HasUsableApi);
+        Assert.Equal(TelegramApiProfilePool.OfficialAndroidApiId.ToString(), status.EffectiveApiId);
+        Assert.Equal("built_in_official", status.EffectiveApiSource);
+        Assert.Equal(TelegramApiProfilePool.OfficialAndroidApiName, status.EffectiveApiName);
+    }
+
+    [Fact]
+    public void ReadTelegramApiRuntimeStatus_PrefersEnabledProfileOverBuiltInFallback()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Telegram:ApiProfiles:0:Name"] = "pool-a",
+                ["Telegram:ApiProfiles:0:ApiId"] = "4001",
+                ["Telegram:ApiProfiles:0:ApiHash"] = HashA,
+                ["Telegram:ApiProfiles:0:Enabled"] = "true"
+            })
+            .Build();
+
+        var status = PanelAdminApiEndpoints.ReadTelegramApiRuntimeStatus(configuration);
+
+        Assert.True(status.HasUsableApi);
+        Assert.Equal("4001", status.EffectiveApiId);
+        Assert.Equal("api_profile", status.EffectiveApiSource);
+        Assert.Equal("pool-a", status.EffectiveApiName);
+    }
+
+    [Fact]
     public void NormalizeTelegramApiDefaultInput_TreatsZeroWithoutHashAsProfileOnly()
     {
         var result = PanelAdminApiEndpoints.NormalizeTelegramApiDefaultInput("0", " ");


### PR DESCRIPTION
## 本次更新
- Telegram API 页面明确区分内置官方 Android API 回退与已写入的自定义 API，空默认 API 且无启用配置池时显示 `effectiveApiSource=built_in_official`。
- `GET /api/panel/settings` 返回有效 API 来源字段：`effectiveApiId`、`effectiveApiSource`、`effectiveApiName`、`officialApiId`、`officialApiName`、`hasUsableApi`。
- 导入页和登录页改用服务端有效 API 状态判断，不再因 `apiId/apiHash` 为空误判内置 API 不可用。
- “改用内置官方 API”会清空自定义默认 API 并停用可保存的配置池项，保存后回退内置官方 API。
- 侧栏拆分为独立的“Telegram API”和“设备指纹”入口，不再保留“Telegram 设置”聚合菜单。
- 手动手机号登录和二维码登录在首次连接前可选择设备指纹，并把 `deviceProfileKey` 冻结到登录状态，登录成功后写入账号。
- 版本提升到 1.31.69。

## 验证
- `pnpm --dir frontend test`：90 通过
- `pnpm --dir frontend run build`：通过；仅 Vite/Rollup 既有 chunk/PURE 注释警告
- `dotnet build TelegramPanel.sln -c Release --no-restore`：通过；仅既有 WindowsBase/MudBlazor/nullable/async 警告
- `dotnet test TelegramPanel.sln -c Release --no-build`：460 通过
- `mkdocs build --strict`：通过；仅既有未纳入 nav 的 `docs/workflows/2026-07/26_reflection_feature_warp-pool.md` 提示