### PR TITLE
fix: 移除设备指纹页 API 状态卡片

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.71</Version>
-    <AssemblyVersion>1.31.71.0</AssemblyVersion>
-    <FileVersion>1.31.71.0</FileVersion>
-    <InformationalVersion>1.31.71</InformationalVersion>
+    <Version>1.31.72</Version>
+    <AssemblyVersion>1.31.72.0</AssemblyVersion>
+    <FileVersion>1.31.72.0</FileVersion>
+    <InformationalVersion>1.31.72</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/developer/documentation.md
+++ b/docs/developer/documentation.md
@@ -67,7 +67,7 @@ uv run mkdocs build
 
 适用版本：包含 `Account.DeviceProfileKey` 与迁移 `20260818090000_AddAccountDeviceProfileKey` 的版本。
 
-- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 是设备画像独立入口；Telegram API 池必须保留在系统设置页，不再新增独立侧栏页。
+- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 是设备画像独立入口，只展示画像目录和默认画像保存，不展示 Telegram API 状态；Telegram API 池必须保留在系统设置页，不再新增独立侧栏页。
 - `TelegramApiProfilePool` 把启用中的内置官方 API 与自定义 API 配置合并成一个池子，并按权重轮询分配给新账号登录和不自带 API 的导入。`Telegram:ApiId`/`Telegram:ApiHash` 仅作旧版单 API 兼容；新版系统设置保存时应把它带入 `ApiProfiles` 并清空旧字段。设置接口必须通过 `telegram.officialApiEnabled`、`telegram.effectiveApiId`、`telegram.effectiveApiSource`、`telegram.officialApiId` 和 `telegram.hasUsableApi` 暴露有效状态，前端不得只用已写入的 `telegram.apiId/apiHash` 判断可用性。
 - `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；手动登录页必须在发送验证码/生成二维码前提交 `deviceProfileKey`，后端需在临时登录状态中冻结该 key，登录成功后保存到账号。代理解析与画像解析相互独立，画像不得改变连接出口。
 - 新登录/导入成功入库时保存画像 key；账号详情更新允许清空 key，表示跟随系统默认。更新画像不改写现有 Session，客户端缓存清理后在下一次创建客户端时生效。

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -62,7 +62,7 @@ Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升
 
 包含设备指纹功能的版本会执行 `20260818090000_AddAccountDeviceProfileKey`，只向 `Accounts` 增加可空的 `DeviceProfileKey` 文本列，不改写现有 Session。升级前备份 `docker-data/telegram-panel.db` 和 `docker-data/appsettings.local.json`。
 
-启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏保留“设备指纹”入口，Telegram API 回到“系统设置”页；系统设置里的 Telegram API 池第一项是可启停的内置官方 API；新登录/导入会在启用项中按权重轮询；设备指纹页能保存默认画像；手动登录页在发送验证码/生成二维码前可选择“本次登录设备指纹”；`GET /api/panel/settings` 返回 `telegram.officialApiEnabled=true` 与 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
+启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏保留“设备指纹”入口，Telegram API 回到“系统设置”页；系统设置里的 Telegram API 池第一项是可启停的内置官方 API；新登录/导入会在启用项中按权重轮询；设备指纹页只显示画像目录并能保存默认画像；手动登录页在发送验证码/生成二维码前可选择“本次登录设备指纹”；`GET /api/panel/settings` 返回 `telegram.officialApiEnabled=true` 与 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
 
 官方 API 作为 API 池顶层项参与轮询；自定义 API 池按权重排在其后，已有账号保存的 ApiId/ApiHash 会优先用于该账号后续操作。关闭内置官方 API 且没有启用自定义项时，新账号登录和不带 API 的导入会提示 Telegram API 不可用。
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -61,7 +61,7 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 
 ### Telegram API 与设备画像
 
-系统设置页管理 Telegram API 池；侧栏 `/device-profiles` 管理内置/自定义设备画像和默认画像。两者最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
+系统设置页管理 Telegram API 池；侧栏 `/device-profiles` 只管理内置/自定义设备画像和默认画像，不展示 Telegram API 状态。两者最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
 
 `GET /api/panel/settings` 返回有效 Telegram API、API 池、启用画像和默认画像 key；`GET /api/panel/settings/device-profiles` 返回同一画像目录的 `{ items, defaultKey }`。
 

--- a/frontend/src/views/TelegramDeviceProfiles.vue
+++ b/frontend/src/views/TelegramDeviceProfiles.vue
@@ -8,91 +8,64 @@
       :title="`写入位置：${settings?.localConfigPath || '-'}`"
     />
 
-    <div class="settings-columns">
-      <div class="settings-column">
-        <el-card shadow="never" class="page-card">
-          <template #header>设备指纹目录</template>
-          <el-form label-position="top">
-            <el-form-item label="默认设备指纹">
-              <el-select v-model="defaultDeviceProfileKey" class="full" filterable>
-                <el-option
-                  v-for="profile in deviceProfiles"
-                  :key="profile.key"
-                  :label="`${profile.name} · ${profile.family}`"
-                  :value="profile.key"
-                />
-              </el-select>
-              <div v-if="selectedDeviceProfile" class="muted mt-2">
-                {{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}
-              </div>
-              <div class="muted mt-2">这里管理 Telegram 客户端的设备画像目录和新账号/导入/连接使用的默认项；单个账号仍可在账号详情里单独覆盖。</div>
-            </el-form-item>
-          </el-form>
-
-          <el-table v-loading="loading" :data="deviceProfiles" stripe class="mt-3">
-            <el-table-column label="Key" min-width="180" prop="key" />
-            <el-table-column label="名称" min-width="180" prop="name" />
-            <el-table-column label="Family" width="120" prop="family" />
-            <el-table-column label="设备参数" min-width="260">
-              <template #default="{ row }">
-                <div class="cell-main">{{ row.deviceModel }}</div>
-                <div class="cell-sub">{{ row.systemVersion }} · App {{ row.appVersion }}</div>
-              </template>
-            </el-table-column>
-            <el-table-column label="语言" width="160">
-              <template #default="{ row }">
-                <div>{{ row.systemLangCode }}</div>
-                <div class="cell-sub">{{ row.langCode }}</div>
-              </template>
-            </el-table-column>
-            <el-table-column label="来源" width="100">
-              <template #default="{ row }">
-                <el-tag :type="row.builtIn ? 'success' : 'info'" size="small">{{ row.builtIn ? '内置' : '自定义' }}</el-tag>
-              </template>
-            </el-table-column>
-            <el-table-column label="备注" min-width="180">
-              <template #default="{ row }">{{ row.notes || '-' }}</template>
-            </el-table-column>
-          </el-table>
-
-          <div class="button-row mt-3">
-            <el-button type="primary" :loading="saving" @click="saveDefaultDeviceProfile">保存默认画像</el-button>
+    <el-card shadow="never" class="page-card">
+      <template #header>设备指纹目录</template>
+      <el-form label-position="top">
+        <el-form-item label="默认设备指纹">
+          <el-select v-model="defaultDeviceProfileKey" class="full" filterable>
+            <el-option
+              v-for="profile in deviceProfiles"
+              :key="profile.key"
+              :label="`${profile.name} · ${profile.family}`"
+              :value="profile.key"
+            />
+          </el-select>
+          <div v-if="selectedDeviceProfile" class="muted mt-2">
+            {{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}
           </div>
-        </el-card>
-      </div>
+          <div class="muted mt-2">这里管理 Telegram 客户端的设备画像目录和新账号/导入/连接使用的默认项；单个账号仍可在账号详情里单独覆盖。</div>
+        </el-form-item>
+      </el-form>
 
-      <div class="settings-column">
-        <el-card shadow="never" class="page-card">
-          <template #header>Telegram API 状态</template>
-          <el-alert type="info" :closable="false" show-icon class="mb-3">
-            <template #title>Telegram API 池在系统设置中管理。</template>
-            <div>这里仅显示当前生效 ApiId、API 来源、启用的自定义 API 数量和默认设备指纹。</div>
-          </el-alert>
-          <el-descriptions :column="1" border size="small">
-            <el-descriptions-item label="当前生效 ApiId">{{ effectiveApiId || '（不可用）' }}</el-descriptions-item>
-            <el-descriptions-item label="当前 API 来源">{{ effectiveApiSourceLabel }}</el-descriptions-item>
-            <el-descriptions-item label="启用中的自定义 API">{{ enabledApiProfiles.length }}</el-descriptions-item>
-            <el-descriptions-item label="当前默认设备指纹">
-              {{ selectedDeviceProfile ? `${selectedDeviceProfile.name} · ${selectedDeviceProfile.family}` : '（未配置）' }}
-            </el-descriptions-item>
-          </el-descriptions>
-          <div class="button-row mt-3">
-            <el-button type="primary" plain @click="router.push('/settings')">去系统设置</el-button>
-          </div>
-        </el-card>
+      <el-table v-loading="loading" :data="deviceProfiles" stripe class="mt-3">
+        <el-table-column label="Key" min-width="180" prop="key" />
+        <el-table-column label="名称" min-width="180" prop="name" />
+        <el-table-column label="Family" width="120" prop="family" />
+        <el-table-column label="设备参数" min-width="260">
+          <template #default="{ row }">
+            <div class="cell-main">{{ row.deviceModel }}</div>
+            <div class="cell-sub">{{ row.systemVersion }} · App {{ row.appVersion }}</div>
+          </template>
+        </el-table-column>
+        <el-table-column label="语言" width="160">
+          <template #default="{ row }">
+            <div>{{ row.systemLangCode }}</div>
+            <div class="cell-sub">{{ row.langCode }}</div>
+          </template>
+        </el-table-column>
+        <el-table-column label="来源" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.builtIn ? 'success' : 'info'" size="small">{{ row.builtIn ? '内置' : '自定义' }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="备注" min-width="180">
+          <template #default="{ row }">{{ row.notes || '-' }}</template>
+        </el-table-column>
+      </el-table>
+
+      <div class="button-row mt-3">
+        <el-button type="primary" :loading="saving" @click="saveDefaultDeviceProfile">保存默认画像</el-button>
       </div>
-    </div>
+    </el-card>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { panelApi } from '@/api/panel'
 import type { SettingsPayload, TelegramApiSettings, TelegramDeviceProfile } from '@/api/types'
 
-const router = useRouter()
 const settings = ref<SettingsPayload | null>(null)
 const loading = ref(false)
 const deviceProfiles = ref<TelegramDeviceProfile[]>([])
@@ -100,16 +73,6 @@ const defaultDeviceProfileKey = ref('')
 const saving = ref(false)
 
 const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === defaultDeviceProfileKey.value))
-const enabledApiProfiles = computed(() => (settings.value?.telegram.profiles || []).filter((profile) => profile.enabled !== false))
-const effectiveApiId = computed(() => settings.value?.telegram.effectiveApiId || settings.value?.system.effectiveApiId || '')
-const effectiveApiSourceLabel = computed(() => {
-  const source = settings.value?.telegram.effectiveApiSource
-  if (source === 'built_in_official') return '内置官方 Android API'
-  if (source === 'api_profile') return settings.value?.telegram.effectiveApiName || 'API 配置池'
-  if (source === 'custom_default') return '旧版单 API'
-  if (source === 'invalid') return '配置不可用'
-  return settings.value ? '未配置' : '加载中'
-})
 
 function normalizeTelegramSettings(source: TelegramApiSettings) {
   deviceProfiles.value = source.deviceProfiles || []
@@ -150,18 +113,6 @@ onMounted(load)
 </script>
 
 <style scoped>
-.settings-columns {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.settings-column {
-  display: grid;
-  gap: 16px;
-  align-content: start;
-}
-
 .button-row {
   display: flex;
   flex-wrap: wrap;
@@ -184,9 +135,4 @@ onMounted(load)
   margin-top: 12px;
 }
 
-@media (max-width: 960px) {
-  .settings-columns {
-    grid-template-columns: 1fr;
-  }
-}
 </style>

--- a/frontend/tests/accountDeviceManagement.test.mjs
+++ b/frontend/tests/accountDeviceManagement.test.mjs
@@ -6,6 +6,7 @@ const typesSource = await readFile(new URL('../src/api/types.ts', import.meta.ur
 const panelSource = await readFile(new URL('../src/api/panel.ts', import.meta.url), 'utf8')
 const accountsSource = await readFile(new URL('../src/views/Accounts.vue', import.meta.url), 'utf8')
 const exportSource = await readFile(new URL('../../src/TelegramPanel.Web/Services/AccountExportService.cs', import.meta.url), 'utf8')
+const deviceProfilesSource = await readFile(new URL('../src/views/TelegramDeviceProfiles.vue', import.meta.url), 'utf8')
 
 test('在线设备授权 hash 使用字符串避免 64 位精度丢失', () => {
   assert.match(typesSource, /export interface TelegramAuthorization \{[\s\S]*hash: string/)
@@ -24,6 +25,14 @@ test('账号详情清空设备画像时提交空字符串', () => {
   assert.match(accountsSource, /<el-option label="跟随系统默认" value="" \/>/)
   assert.match(accountsSource, /deviceProfileKey: details\.form\.deviceProfileKey,/)
   assert.doesNotMatch(accountsSource, /deviceProfileKey: details\.form\.deviceProfileKey \|\| null/)
+})
+
+test('设备指纹页只展示画像目录不展示 API 状态', () => {
+  assert.match(deviceProfilesSource, /<template #header>设备指纹目录<\/template>/)
+  assert.match(deviceProfilesSource, /保存默认画像/)
+  assert.doesNotMatch(deviceProfilesSource, /Telegram API 状态/)
+  assert.doesNotMatch(deviceProfilesSource, /去系统设置/)
+  assert.doesNotMatch(deviceProfilesSource, /effectiveApiSource/)
 })
 
 test('导出独立 session 注入当前授权的设备画像', () => {


### PR DESCRIPTION
## 改动目标

设备指纹页只保留设备画像目录和默认画像保存，不再展示 Telegram API 状态卡片。

## 主要改动

- 删除 `frontend/src/views/TelegramDeviceProfiles.vue` 右侧 Telegram API 状态卡片。
- 清理页面内 API 来源/生效 ApiId/跳转系统设置相关计算和路由依赖。
- 新增前端测试，约束设备指纹页不再出现 API 状态、去系统设置、`effectiveApiSource`。
- 同步开发文档、API 参考和升级验收说明。
- 版本提升到 `1.31.72`。

## 验证

- `dotnet build TelegramPanel.sln -c Release --no-restore`：通过，存在既有 nullable/MudBlazor/WindowsBase 警告。
- `dotnet test TelegramPanel.sln -c Release --no-build`：通过，464/464。
- `pnpm --dir frontend run build`：通过，存在既有 Rollup pure annotation/chunk size 警告。
- `pnpm --dir frontend test`：通过，91/91。
- `mkdocs build --strict`：通过，存在既有 MkDocs 2.0/历史页面未纳入 nav 提示。
- 本地 no-auth smoke：`/ui/device-profiles` 返回 200；浏览器快照只显示“设备指纹目录”、画像表格和“保存默认画像”，没有 “Telegram API 状态” 卡片。

## 文档入口

- `docs/developer/documentation.md`
- `docs/reference/api.md`
- `docs/getting-started/update.md`

## 部署与回滚

合并到 `dev` 后构建 `dev-latest` 并部署验收；合并 `main` 后发布 v1.31.72。回滚只需恢复上一镜像/版本。