### PR TITLE
fix: 支持随机默认设备指纹

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.72</Version>
-    <AssemblyVersion>1.31.72.0</AssemblyVersion>
-    <FileVersion>1.31.72.0</FileVersion>
-    <InformationalVersion>1.31.72</InformationalVersion>
+    <Version>1.31.73</Version>
+    <AssemblyVersion>1.31.73.0</AssemblyVersion>
+    <FileVersion>1.31.73.0</FileVersion>
+    <InformationalVersion>1.31.73</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 

--- a/docs/developer/documentation.md
+++ b/docs/developer/documentation.md
@@ -67,13 +67,13 @@ uv run mkdocs build
 
 适用版本：包含 `Account.DeviceProfileKey` 与迁移 `20260818090000_AddAccountDeviceProfileKey` 的版本。
 
-- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。侧栏 `/device-profiles` 是设备画像独立入口，只展示画像目录和默认画像保存，不展示 Telegram API 状态；Telegram API 池必须保留在系统设置页，不再新增独立侧栏页。
+- `TelegramDeviceProfileCatalog` 是唯一画像解析入口；未知、停用或空 key 必须回退系统默认画像，不得在各服务中复制默认值。保留 key `random` 表示不绑定目录项，而是按账号/会话 stable key 走 `TelegramClientDeviceProfile.ForStableKey` 稳定随机生成画像；自定义目录不得复用该 key。侧栏 `/device-profiles` 是设备画像独立入口，只展示画像目录和默认画像保存，不展示 Telegram API 状态；默认画像下拉必须把“随机设备指纹”作为首项单独展示，Telegram API 池必须保留在系统设置页，不再新增独立侧栏页。
 - `TelegramApiProfilePool` 把启用中的内置官方 API 与自定义 API 配置合并成一个池子，并按权重轮询分配给新账号登录和不自带 API 的导入。`Telegram:ApiId`/`Telegram:ApiHash` 仅作旧版单 API 兼容；新版系统设置保存时应把它带入 `ApiProfiles` 并清空旧字段。设置接口必须通过 `telegram.officialApiEnabled`、`telegram.effectiveApiId`、`telegram.effectiveApiSource`、`telegram.officialApiId` 和 `telegram.hasUsableApi` 暴露有效状态，前端不得只用已写入的 `telegram.apiId/apiHash` 判断可用性。
 - `TelegramClientPool`、Session 导入验证、账号导出和账号登录必须在创建 `WTelegram.Client` 前解析画像；手动登录页必须在发送验证码/生成二维码前提交 `deviceProfileKey`，后端需在临时登录状态中冻结该 key，登录成功后保存到账号。代理解析与画像解析相互独立，画像不得改变连接出口。
 - 新登录/导入成功入库时保存画像 key；账号详情更新允许清空 key，表示跟随系统默认。更新画像不改写现有 Session，客户端缓存清理后在下一次创建客户端时生效。
-- API 端点：`GET /api/panel/settings` 返回有效 Telegram API、来源字段、`officialApiEnabled` 与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录；`POST /api/panel/settings/telegram-api` 保存 API 池、内置官方 API 启用状态和默认画像；账号 `PUT /api/panel/accounts/{id}` 和登录/导入请求接受 `deviceProfileKey`。
+- API 端点：`GET /api/panel/settings` 返回有效 Telegram API、来源字段、`officialApiEnabled` 与 `telegram.deviceProfiles`；`GET /api/panel/settings/device-profiles` 返回画像目录和可为 `random` 的默认 key；`POST /api/panel/settings/telegram-api` 保存 API 池、内置官方 API 启用状态和默认画像；账号 `PUT /api/panel/accounts/{id}` 和登录/导入请求接受画像 key、空字符串和 `random`。
 
-验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查系统设置中的 Telegram API 池、内置官方 API 顶部项、API 池轮询、设备指纹页面、手动登录设备指纹选择、账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
+验证：运行 .NET Release 构建和完整 Web 测试；运行前端 `vue-tsc`/build 与前端测试；手工检查系统设置中的 Telegram API 池、内置官方 API 顶部项、API 池轮询、设备指纹页面默认画像下拉首项“随机设备指纹”、手动登录设备指纹选择、账号详情清空/保存及新客户端创建。失败排查先检查迁移、画像 key、API 配置和本地配置文件权限。回滚需先备份数据库和 `appsettings.local.json`，再恢复旧程序；旧程序不会使用画像字段，但不应删除迁移历史。
 
 ## GitHub Pages 发布
 

--- a/docs/getting-started/update.md
+++ b/docs/getting-started/update.md
@@ -62,7 +62,7 @@ Cloudflare R2 预签名 `PUT` URL 若返回 `Missing x-amz-content-sha256`，升
 
 包含设备指纹功能的版本会执行 `20260818090000_AddAccountDeviceProfileKey`，只向 `Accounts` 增加可空的 `DeviceProfileKey` 文本列，不改写现有 Session。升级前备份 `docker-data/telegram-panel.db` 和 `docker-data/appsettings.local.json`。
 
-启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏保留“设备指纹”入口，Telegram API 回到“系统设置”页；系统设置里的 Telegram API 池第一项是可启停的内置官方 API；新登录/导入会在启用项中按权重轮询；设备指纹页只显示画像目录并能保存默认画像；手动登录页在发送验证码/生成二维码前可选择“本次登录设备指纹”；`GET /api/panel/settings` 返回 `telegram.officialApiEnabled=true` 与 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
+启动后验收：容器状态为 running；`/api/panel/auth/me` 返回 200；侧栏保留“设备指纹”入口，Telegram API 回到“系统设置”页；系统设置里的 Telegram API 池第一项是可启停的内置官方 API；新登录/导入会在启用项中按权重轮询；设备指纹页只显示画像目录，默认设备指纹下拉首项为“随机设备指纹”且能保存默认画像；手动登录页在发送验证码/生成二维码前可选择“本次登录设备指纹”；`GET /api/panel/settings` 返回 `telegram.officialApiEnabled=true` 与 `telegram.effectiveApiSource=built_in_official`；账号详情能保存和清空单账号画像；导入页能提交所选画像。若迁移失败，保留容器日志和数据库备份，不要手工删列或删除 `__EFMigrationsHistory`；先停止容器并恢复升级前快照，再回滚到旧镜像。
 
 官方 API 作为 API 池顶层项参与轮询；自定义 API 池按权重排在其后，已有账号保存的 ApiId/ApiHash 会优先用于该账号后续操作。关闭内置官方 API 且没有启用自定义项时，新账号登录和不带 API 的导入会提示 Telegram API 不可用。
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -63,9 +63,9 @@ Vue 后台使用 `/api/panel` 下的管理接口。开启后台登录时，除�
 
 系统设置页管理 Telegram API 池；侧栏 `/device-profiles` 只管理内置/自定义设备画像和默认画像，不展示 Telegram API 状态。两者最终都通过 `POST /api/panel/settings/telegram-api` 保存，设备画像请求沿用现有 `deviceProfiles` 与 `defaultDeviceProfileKey` 字段。
 
-`GET /api/panel/settings` 返回有效 Telegram API、API 池、启用画像和默认画像 key；`GET /api/panel/settings/device-profiles` 返回同一画像目录的 `{ items, defaultKey }`。
+`GET /api/panel/settings` 返回有效 Telegram API、API 池、启用画像和默认画像 key；`GET /api/panel/settings/device-profiles` 返回同一画像目录的 `{ items, defaultKey }`。`defaultDeviceProfileKey`/`defaultKey` 可以是保留值 `random`，表示按账号或会话稳定随机选取适合当前 API 的内置画像；`random` 不属于 `items` 画像目录，前端必须作为下拉首项单独展示。
 
-`PUT /api/panel/accounts/{id}` 的请求可携带 `deviceProfileKey`：传画像 key 表示绑定该账号，传空字符串表示清除绑定并跟随系统默认。`GET /api/panel/accounts/{id}` 返回 `deviceProfileKey`。`POST /api/panel/accounts/import/zip`、`POST /api/panel/accounts/import/session-files` 的 multipart 字段名为 `deviceProfileKey`；StringSession JSON 请求同名字段。`POST /api/panel/accounts/login/start` 与 `POST /api/panel/accounts/login/qr/start` 也接受 `deviceProfileKey`，在发送验证码或生成二维码前应用该画像，并在登录成功后保存到账号。未知或停用 key 返回 `400` 或业务失败响应，不会修改账号。
+`PUT /api/panel/accounts/{id}` 的请求可携带 `deviceProfileKey`：传画像 key 表示绑定该账号，传 `random` 表示该账号后续按稳定随机画像连接，传空字符串表示清除绑定并跟随系统默认。`GET /api/panel/accounts/{id}` 返回 `deviceProfileKey`。`POST /api/panel/accounts/import/zip`、`POST /api/panel/accounts/import/session-files` 的 multipart 字段名为 `deviceProfileKey`；StringSession JSON 请求同名字段。`POST /api/panel/accounts/login/start` 与 `POST /api/panel/accounts/login/qr/start` 也接受 `deviceProfileKey`，在发送验证码或生成二维码前应用该画像，并在登录成功后保存到账号。未知或停用 key 返回 `400` 或业务失败响应，不会修改账号。
 
 成功判据是保存后重新读取账号详情仍返回该 key，清空后返回 `null`；画像只影响客户端设备字段，不改变 API 凭据、代理策略或 Session 文件格式。数据库列由 `20260818090000_AddAccountDeviceProfileKey` 迁移创建。
 

--- a/frontend/src/views/AccountImport.vue
+++ b/frontend/src/views/AccountImport.vue
@@ -98,6 +98,7 @@
         </div>
       </div>
       <el-select v-model="deviceProfileKey" class="category-select" filterable :disabled="busy">
+        <el-option label="随机设备指纹" value="random" />
         <el-option
           v-for="profile in deviceProfiles"
           :key="profile.key"

--- a/frontend/src/views/AccountLogin.vue
+++ b/frontend/src/views/AccountLogin.vue
@@ -69,6 +69,7 @@
           </div>
         </div>
         <el-select v-model="deviceProfileKey" class="login-device-select" filterable :disabled="proxyRouteLocked">
+          <el-option label="随机设备指纹" value="random" />
           <el-option
             v-for="profile in deviceProfiles"
             :key="profile.key"
@@ -76,7 +77,11 @@
             :label="`${profile.name} · ${profile.family}`"
           />
         </el-select>
-        <div v-if="selectedDeviceProfile" class="login-device-summary">
+        <div v-if="randomDeviceProfileSelected" class="login-device-summary">
+          <span class="material-icons">casino</span>
+          <span>按账号/会话稳定随机选择适合当前 API 的内置画像</span>
+        </div>
+        <div v-else-if="selectedDeviceProfile" class="login-device-summary">
           <span class="material-icons">devices</span>
           <span>{{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}</span>
         </div>
@@ -407,6 +412,7 @@ const proxySelectionInvalid = computed(() =>
   || (proxyStrategy.value === 'warp_pool' && availableWarpPoolCount.value === 0),
 )
 const proxyRouteLocked = computed(() => logging.value || hasActiveLoginSession.value)
+const randomDeviceProfileSelected = computed(() => deviceProfileKey.value === 'random')
 const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === deviceProfileKey.value))
 
 const stepIndex = computed(() => {

--- a/frontend/src/views/Accounts.vue
+++ b/frontend/src/views/Accounts.vue
@@ -256,6 +256,7 @@
           <el-form-item label="设备指纹">
             <el-select v-model="details.form.deviceProfileKey" class="full" filterable>
               <el-option label="跟随系统默认" value="" />
+              <el-option label="随机设备指纹" value="random" />
               <el-option
                 v-for="profileOption in deviceProfiles"
                 :key="profileOption.key"
@@ -263,7 +264,7 @@
                 :value="profileOption.key"
               />
             </el-select>
-            <div class="form-hint no-offset">仅影响该账号后续 Telegram 客户端连接；留空时使用系统默认设备画像。</div>
+            <div class="form-hint no-offset">仅影响该账号后续 Telegram 客户端连接；留空时使用系统默认，选择随机时会按账号稳定选取画像。</div>
           </el-form-item>
         </el-form>
       </template>

--- a/frontend/src/views/TelegramDeviceProfiles.vue
+++ b/frontend/src/views/TelegramDeviceProfiles.vue
@@ -13,6 +13,7 @@
       <el-form label-position="top">
         <el-form-item label="默认设备指纹">
           <el-select v-model="defaultDeviceProfileKey" class="full" filterable>
+            <el-option label="随机设备指纹" value="random" />
             <el-option
               v-for="profile in deviceProfiles"
               :key="profile.key"
@@ -20,7 +21,10 @@
               :value="profile.key"
             />
           </el-select>
-          <div v-if="selectedDeviceProfile" class="muted mt-2">
+          <div v-if="randomDeviceProfileSelected" class="muted mt-2">
+            按账号/会话稳定随机选择适合当前 API 的内置画像，避免所有新账号共用同一设备参数。
+          </div>
+          <div v-else-if="selectedDeviceProfile" class="muted mt-2">
             {{ selectedDeviceProfile.deviceModel }} · {{ selectedDeviceProfile.systemVersion }} · App {{ selectedDeviceProfile.appVersion }}
           </div>
           <div class="muted mt-2">这里管理 Telegram 客户端的设备画像目录和新账号/导入/连接使用的默认项；单个账号仍可在账号详情里单独覆盖。</div>
@@ -72,6 +76,7 @@ const deviceProfiles = ref<TelegramDeviceProfile[]>([])
 const defaultDeviceProfileKey = ref('')
 const saving = ref(false)
 
+const randomDeviceProfileSelected = computed(() => defaultDeviceProfileKey.value === 'random')
 const selectedDeviceProfile = computed(() => deviceProfiles.value.find((profile) => profile.key === defaultDeviceProfileKey.value))
 
 
@@ -94,6 +99,7 @@ async function load() {
 async function saveDefaultDeviceProfile() {
   saving.value = true
   try {
+    const requestedDefaultKey = defaultDeviceProfileKey.value
     const current = await panelApi.settings()
     const result = await panelApi.saveTelegramApiSettings({
       apiId: current.telegram.apiId,
@@ -101,10 +107,11 @@ async function saveDefaultDeviceProfile() {
       profiles: current.telegram.profiles,
       officialApiEnabled: current.telegram.officialApiEnabled !== false,
       deviceProfiles: current.telegram.deviceProfiles || [],
-      defaultDeviceProfileKey: defaultDeviceProfileKey.value,
+      defaultDeviceProfileKey: requestedDefaultKey,
     })
     if (result.message) ElMessage.success(result.message)
     await load()
+    defaultDeviceProfileKey.value = requestedDefaultKey
   } finally {
     saving.value = false
   }

--- a/frontend/tests/accountDeviceManagement.test.mjs
+++ b/frontend/tests/accountDeviceManagement.test.mjs
@@ -7,6 +7,8 @@ const panelSource = await readFile(new URL('../src/api/panel.ts', import.meta.ur
 const accountsSource = await readFile(new URL('../src/views/Accounts.vue', import.meta.url), 'utf8')
 const exportSource = await readFile(new URL('../../src/TelegramPanel.Web/Services/AccountExportService.cs', import.meta.url), 'utf8')
 const deviceProfilesSource = await readFile(new URL('../src/views/TelegramDeviceProfiles.vue', import.meta.url), 'utf8')
+const importSource = await readFile(new URL('../src/views/AccountImport.vue', import.meta.url), 'utf8')
+const loginSource = await readFile(new URL('../src/views/AccountLogin.vue', import.meta.url), 'utf8')
 
 test('在线设备授权 hash 使用字符串避免 64 位精度丢失', () => {
   assert.match(typesSource, /export interface TelegramAuthorization \{[\s\S]*hash: string/)
@@ -30,6 +32,11 @@ test('账号详情清空设备画像时提交空字符串', () => {
 test('设备指纹页只展示画像目录不展示 API 状态', () => {
   assert.match(deviceProfilesSource, /<template #header>设备指纹目录<\/template>/)
   assert.match(deviceProfilesSource, /保存默认画像/)
+  assert.match(deviceProfilesSource, /<el-option label="随机设备指纹" value="random" \/>[\s\S]*v-for="profile in deviceProfiles"/)
+  assert.match(importSource, /<el-option label="随机设备指纹" value="random" \/>[\s\S]*v-for="profile in deviceProfiles"/)
+  assert.match(loginSource, /<el-option label="随机设备指纹" value="random" \/>[\s\S]*v-for="profile in deviceProfiles"/)
+  assert.match(accountsSource, /<el-option label="随机设备指纹" value="random" \/>[\s\S]*v-for="profileOption in deviceProfiles"/)
+  assert.match(deviceProfilesSource, /const requestedDefaultKey = defaultDeviceProfileKey\.value[\s\S]*defaultDeviceProfileKey: requestedDefaultKey[\s\S]*defaultDeviceProfileKey\.value = requestedDefaultKey/)
   assert.doesNotMatch(deviceProfilesSource, /Telegram API 状态/)
   assert.doesNotMatch(deviceProfilesSource, /去系统设置/)
   assert.doesNotMatch(deviceProfilesSource, /effectiveApiSource/)

--- a/src/TelegramPanel.Core/Services/Telegram/TelegramDeviceProfileCatalog.cs
+++ b/src/TelegramPanel.Core/Services/Telegram/TelegramDeviceProfileCatalog.cs
@@ -26,6 +26,7 @@ public sealed record TelegramDeviceProfileDefinition(
 public static class TelegramDeviceProfileCatalog
 {
     public const string DefaultProfileKey = "android-default";
+    public const string RandomProfileKey = "random";
 
     private static readonly TelegramDeviceProfileDefinition[] BuiltInProfiles =
     {
@@ -41,7 +42,7 @@ public static class TelegramDeviceProfileCatalog
         foreach (var child in configuration.GetSection("Telegram:DeviceProfiles").GetChildren())
         {
             var key = NormalizeKey(child["Key"]);
-            if (string.IsNullOrWhiteSpace(key))
+            if (string.IsNullOrWhiteSpace(key) || IsRandomProfileKey(key))
                 continue;
 
             var fallback = BuiltInProfiles.FirstOrDefault(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
@@ -75,7 +76,9 @@ public static class TelegramDeviceProfileCatalog
     public static string ResolveDefaultKey(IConfiguration configuration)
     {
         var requested = NormalizeKey(configuration["Telegram:DefaultDeviceProfileKey"]);
-        return string.IsNullOrWhiteSpace(requested) ? DefaultProfileKey : requested;
+        if (string.IsNullOrWhiteSpace(requested))
+            return DefaultProfileKey;
+        return IsRandomProfileKey(requested) ? RandomProfileKey : requested;
     }
 
     public static TelegramDeviceProfileDefinition? Find(IConfiguration configuration, string? key)
@@ -83,6 +86,8 @@ public static class TelegramDeviceProfileCatalog
         var normalized = NormalizeKey(key);
         if (string.IsNullOrWhiteSpace(normalized))
             normalized = ResolveDefaultKey(configuration);
+        if (IsRandomProfileKey(normalized))
+            return null;
         return ReadProfiles(configuration).FirstOrDefault(x => string.Equals(x.Key, normalized, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -98,6 +103,35 @@ public static class TelegramDeviceProfileCatalog
 
     public static string NormalizeKey(string? value) =>
         (value ?? string.Empty).Trim().ToLowerInvariant();
+
+    public static bool IsRandomProfileKey(string? value) =>
+        string.Equals(NormalizeKey(value), RandomProfileKey, StringComparison.Ordinal);
+
+    public static bool TryNormalizeSelectableKey(IConfiguration configuration, string? key, out string? normalizedKey)
+    {
+        var requested = NormalizeKey(key);
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            normalizedKey = null;
+            return true;
+        }
+
+        if (IsRandomProfileKey(requested))
+        {
+            normalizedKey = RandomProfileKey;
+            return true;
+        }
+
+        var profile = Find(configuration, requested);
+        if (profile == null)
+        {
+            normalizedKey = null;
+            return false;
+        }
+
+        normalizedKey = profile.Key;
+        return true;
+    }
 
     private static string NormalizeText(string? value, string fallback) =>
         string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();

--- a/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
+++ b/src/TelegramPanel.Web/Api/PanelAdminApiEndpoints.cs
@@ -537,9 +537,7 @@ public static class PanelAdminApiEndpoints
             account.CategoryId = request.CategoryId.Value <= 0 ? null : request.CategoryId.Value;
         if (request.DeviceProfileKey != null)
         {
-            var profileKey = NormalizeNullable(request.DeviceProfileKey);
-            if (!string.IsNullOrWhiteSpace(profileKey)
-                && TelegramDeviceProfileCatalog.Find(configuration, profileKey) == null)
+            if (!TelegramDeviceProfileCatalog.TryNormalizeSelectableKey(configuration, request.DeviceProfileKey, out var profileKey))
                 return Results.BadRequest(new OperationResultDto(false, "设备指纹不存在或已停用"));
             account.DeviceProfileKey = profileKey;
         }
@@ -2510,10 +2508,9 @@ public static class PanelAdminApiEndpoints
             telegram["ApiId"] = 0;
             telegram["ApiHash"] = string.Empty;
         }
-        var selectedDeviceProfile = TelegramDeviceProfileCatalog.Find(configuration, request.DefaultDeviceProfileKey);
-        if (!string.IsNullOrWhiteSpace(request.DefaultDeviceProfileKey) && selectedDeviceProfile == null)
+        if (!TelegramDeviceProfileCatalog.TryNormalizeSelectableKey(configuration, request.DefaultDeviceProfileKey, out var selectedDeviceProfileKey))
             return Results.BadRequest(new OperationResultDto(false, "默认设备指纹不存在或已停用"));
-        telegram["DefaultDeviceProfileKey"] = selectedDeviceProfile?.Key ?? TelegramDeviceProfileCatalog.DefaultProfileKey;
+        telegram["DefaultDeviceProfileKey"] = selectedDeviceProfileKey ?? TelegramDeviceProfileCatalog.DefaultProfileKey;
         telegram["OfficialApiEnabled"] = request.OfficialApiEnabled;
         var normalizedProfiles = new JsonArray();
         foreach (var profile in profiles)
@@ -7038,10 +7035,9 @@ public static class PanelAdminApiEndpoints
         {
             throw new InvalidOperationException(apiError);
         }
-        var selectedDeviceProfile = TelegramDeviceProfileCatalog.Find(configuration, deviceProfileKey);
-        if (!string.IsNullOrWhiteSpace(deviceProfileKey) && selectedDeviceProfile == null)
+        if (!TelegramDeviceProfileCatalog.TryNormalizeSelectableKey(configuration, deviceProfileKey, out var selectedDeviceProfileKey))
             throw new InvalidOperationException("登录设备指纹不存在或已停用");
-        var savedDeviceProfileKey = selectedDeviceProfile?.Key ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration);
+        var savedDeviceProfileKey = selectedDeviceProfileKey ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration);
 
 
         var sessionsPath = configuration["Telegram:SessionsPath"] ?? "sessions";

--- a/src/TelegramPanel.Web/Services/AccountLoginProxyCoordinator.cs
+++ b/src/TelegramPanel.Web/Services/AccountLoginProxyCoordinator.cs
@@ -554,10 +554,9 @@ public sealed class AccountLoginProxyCoordinator
         ResinLeaseControlSnapshot? resinLease = null;
         string? temporaryResinKey = null;
         int? ownedWarpProxyId = null;
-        var selectedDeviceProfile = TelegramDeviceProfileCatalog.Find(_configuration, deviceProfileKey);
-        if (!string.IsNullOrWhiteSpace(deviceProfileKey) && selectedDeviceProfile == null)
+        if (!TelegramDeviceProfileCatalog.TryNormalizeSelectableKey(_configuration, deviceProfileKey, out var selectedDeviceProfileKey))
             throw new ArgumentException("登录设备指纹不存在或已停用");
-        var normalizedDeviceProfileKey = selectedDeviceProfile?.Key ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(_configuration);
+        var normalizedDeviceProfileKey = selectedDeviceProfileKey ?? TelegramDeviceProfileCatalog.ResolveDefaultKey(_configuration);
 
         IDisposable? warpRequestClaim = null;
 

--- a/tests/TelegramPanel.Web.Tests/ManualLoginProxyRoutingTests.cs
+++ b/tests/TelegramPanel.Web.Tests/ManualLoginProxyRoutingTests.cs
@@ -738,6 +738,25 @@ public sealed class ManualLoginProxyRoutingTests
         Assert.False(fixture.Coordinator.HasState(1801));
     }
 
+    [Fact]
+    public async Task 手动登录首次连接允许随机设备指纹Key()
+    {
+        await using var fixture = await Fixture.CreateAsync();
+
+        var state = await fixture.Coordinator.PrepareAsync(
+            1802,
+            "direct",
+            null,
+            CancellationToken.None,
+            TelegramDeviceProfileCatalog.RandomProfileKey);
+
+        Assert.Equal(TelegramDeviceProfileCatalog.RandomProfileKey, state.DeviceProfileKey);
+        Assert.Equal(TelegramDeviceProfileCatalog.RandomProfileKey, fixture.Coordinator.GetDeviceProfileKey(1802));
+
+        await fixture.Coordinator.AbandonAsync(1802);
+        Assert.False(fixture.Coordinator.HasState(1802));
+    }
+
     private sealed class Fixture : IAsyncDisposable
     {
         private readonly SqliteConnection _connection;

--- a/tests/TelegramPanel.Web.Tests/TelegramDeviceProfileCatalogTests.cs
+++ b/tests/TelegramPanel.Web.Tests/TelegramDeviceProfileCatalogTests.cs
@@ -20,6 +20,45 @@ public sealed class TelegramDeviceProfileCatalogTests
     }
 
     [Fact]
+    public void RandomDefaultKeyUsesStableGeneratedProfile()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Telegram:DefaultDeviceProfileKey"] = "random"
+            })
+            .Build();
+
+        var profile = TelegramDeviceProfileCatalog.ResolveClientProfile(
+            configuration,
+            6,
+            null,
+            "stable-key");
+
+        Assert.Equal(TelegramDeviceProfileCatalog.RandomProfileKey, TelegramDeviceProfileCatalog.ResolveDefaultKey(configuration));
+        Assert.Equal(TelegramClientDeviceProfile.ForStableKey(6, "stable-key"), profile);
+    }
+
+    [Fact]
+    public void RandomKeyIsSelectableButReservedFromConfiguredCatalog()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Telegram:DeviceProfiles:0:Key"] = "random",
+                ["Telegram:DeviceProfiles:0:Name"] = "Should Not Appear",
+                ["Telegram:DeviceProfiles:0:Enabled"] = "true"
+            })
+            .Build();
+
+        var profiles = TelegramDeviceProfileCatalog.ReadProfiles(configuration);
+
+        Assert.True(TelegramDeviceProfileCatalog.TryNormalizeSelectableKey(configuration, "random", out var normalizedKey));
+        Assert.Equal(TelegramDeviceProfileCatalog.RandomProfileKey, normalizedKey);
+        Assert.DoesNotContain(profiles, profile => profile.Key == TelegramDeviceProfileCatalog.RandomProfileKey);
+    }
+
+    [Fact]
     public void ConfiguredProfileOverridesBuiltInValues()
     {
         var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
## 目标\n\n默认设备指纹下拉新增顶部项“随机设备指纹”，并允许系统默认、登录/导入/账号详情保存保留 key `random`。\n\n## 本次更新\n\n- 新增 `TelegramDeviceProfileCatalog.RandomProfileKey` 与统一校验入口，`random` 走 stable key 生成画像，不进入自定义画像目录。\n- 设备指纹页默认画像下拉顶部显示“随机设备指纹”，保存后保持该选项可见。\n- 手动登录、导入账号、账号详情设备指纹下拉同步支持 `random`。\n- 更新 API/开发/升级文档，明确 `random` 是保留 key。\n- 版本提升到 `1.31.73`。\n\n## 验证\n\n- `dotnet build TelegramPanel.sln -c Release --no-restore`\n- `dotnet test TelegramPanel.sln -c Release --no-build`\n- `pnpm --dir frontend test`\n- `pnpm --dir frontend run build`\n- `mkdocs build --strict`\n- 本地 smoke：`/ui/device-profiles` 默认设备指纹下拉首项为“随机设备指纹”；选择并保存后 `/api/panel/settings` 返回 `telegram.defaultDeviceProfileKey=random`，页面保持“随机设备指纹”选中。\n\n## 部署与回滚\n\n合并到 `dev` 后构建 `dev-latest` 并部署云端验收；回滚只需恢复上一镜像/版本与原 `appsettings.local.json`，无数据库迁移。\n