### PR TITLE
release: 准备 v1.31.75 版本元数据

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <!-- 主版本: 重大变更/不兼容更新 -->
     <!-- 次版本: 新功能/兼容性更新 -->
     <!-- 修订号: Bug修复/小改进 -->
-    <Version>1.31.74</Version>
-    <AssemblyVersion>1.31.74.0</AssemblyVersion>
-    <FileVersion>1.31.74.0</FileVersion>
-    <InformationalVersion>1.31.74</InformationalVersion>
+    <Version>1.31.75</Version>
+    <AssemblyVersion>1.31.75.0</AssemblyVersion>
+    <FileVersion>1.31.75.0</FileVersion>
+    <InformationalVersion>1.31.75</InformationalVersion>
     <!-- Release 包、version.txt 与 tag 必须完全一致，禁止 SDK 自动追加 +GitSha。 -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 


### PR DESCRIPTION
## 变更说明

- 将 Version、AssemblyVersion、FileVersion、InformationalVersion 统一升级到 1.31.75。
- 为 Issues #156、#157、#158 的 dev 验收和正式发布准备一致的版本元数据。

## 验证与发布路径

- 版本字段保持一致，tag v1.31.75 将由工作流严格校验。
- 合并 dev 后构建 dev-latest，完成云端验收，再合并 main 并创建正式 Release。

## 关联

- 关联 PR #161 合并后的 dev 基线。